### PR TITLE
Implement client system type reporting

### DIFF
--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -186,7 +186,7 @@ namespace OrganizadorArquivosWPF
                     _pastaOrigem,
                     record,
                     record.Empresa,
-                    record.TipoDesigfi == "SIGFI160",
+                    record.TipoDesigfi,
                     false,
                     string.Empty,
                     _usuario.NomeUsuario,
@@ -229,7 +229,7 @@ namespace OrganizadorArquivosWPF
                             Rota = fb.Rota,
                             IdSigfi = fb.IdSigfi,
                             Empresa = "HOPPECKE",
-                            TipoDesigfi = fb.Is160 ? "SIGFI160" : string.Empty,
+                            TipoDesigfi = fb.TipoSistema,
                             NomeCliente = fb.ClienteEncontrado ?? "[NOME DESCONHECIDO]"
                         };
                     }

--- a/OrganizadorArquivosWPF/Services/RenamerService.cs
+++ b/OrganizadorArquivosWPF/Services/RenamerService.cs
@@ -168,7 +168,7 @@ namespace OrganizadorArquivosWPF.Services
             string sourceFolder,
             ClientRecord record,
             string sistema,
-            bool isSistema160,
+            string tipoSistema,
             bool isDevMode,
             string devDestino,
             string nomeFuncionario,
@@ -178,6 +178,7 @@ namespace OrganizadorArquivosWPF.Services
             // Task.Run mantém compatibilidade com .NET 4.x (não há async streams etc.)
             return Task.Run(() =>
             {
+                bool isSistema160 = string.Equals(tipoSistema, "SIGFI160", StringComparison.OrdinalIgnoreCase);
                 int pct = 0;
                 void Report(int v) { pct = v; progress?.Report(v); }
 
@@ -204,7 +205,7 @@ namespace OrganizadorArquivosWPF.Services
                     { "Matrícula", matriculaFuncionario },
                     { "Empresa", RaizOneEng },
                     { "Tipo de Sistema", sistema },
-                    { "Sistema 160", isSistema160 ? "SIM" : "NÃO" },
+                    { "Sistema do Cliente", tipoSistema },
                     { "Versão do Programa", Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "(N/A)" },
                     { "Usuário Windows", Environment.UserName },
                     { "Data/Hora", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture) },

--- a/OrganizadorArquivosWPF/Views/FallbackWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/Views/FallbackWindow.xaml.cs
@@ -19,6 +19,7 @@ namespace OrganizadorArquivosWPF.Views
         public string Rota { get; private set; }
         public string IdSigfi { get; private set; }
         public bool Is160 => Chk160.IsChecked == true;
+        public string TipoSistema => Is160 ? "SIGFI160" : "OUTRO";
 
         // Guarda a UF selecionada no MainWindow
         private readonly string _ufPrefixo;


### PR DESCRIPTION
## Summary
- return system type string from `FallbackWindow`
- record system type and pass it through `MainWindow` to `RenameAsync`
- log client's system type in `RenamerService`

## Testing
- `xbuild OrganizadorArquivosWPF.sln` *(fails: Method `NormalizePath(...)` arguments cannot be evaluated)*

------
https://chatgpt.com/codex/tasks/task_e_684c67eb731483339c98f6667bd9d702