### PR TITLE
Handle manutencao feed as XML

### DIFF
--- a/OrganizadorArquivosWPF/Services/ManutencoesService.cs
+++ b/OrganizadorArquivosWPF/Services/ManutencoesService.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using System.Xml.Linq;
 
 namespace OrganizadorArquivosWPF.Services
 {
@@ -25,7 +26,8 @@ namespace OrganizadorArquivosWPF.Services
         /// </summary>
         public async Task<JArray> ObterDadosAsync()
         {
-            string json = null;
+            // texto em XML baixado da web
+            string xml = null;
 
             if (TemInternet())
             {
@@ -33,33 +35,66 @@ namespace OrganizadorArquivosWPF.Services
                 {
                     using (var http = new HttpClient())
                     {
-                        json = await http.GetStringAsync(ApiUrl);
+                        xml = await http.GetStringAsync(ApiUrl);
+                        // valida e converte para JSON antes de salvar
+                        var array = ConverterXmlParaArray(xml);
                         Directory.CreateDirectory(Path.GetDirectoryName(OfflinePath));
-                        File.WriteAllText(OfflinePath, json, Encoding.UTF8);
+                        File.WriteAllText(OfflinePath, array.ToString(), Encoding.UTF8);
+                        return array;
                     }
                 }
                 catch
                 {
-                    json = null; // falha na conexão, tenta local
+                    xml = null; // falha na conexão ou XML inválido
                 }
             }
 
-            if (json == null)
+            if (xml == null)
             {
                 if (!File.Exists(OfflinePath))
                     return new JArray();
 
-                json = File.ReadAllText(OfflinePath, Encoding.UTF8);
+                try
+                {
+                    var offlineJson = File.ReadAllText(OfflinePath, Encoding.UTF8);
+                    return JArray.Parse(offlineJson);
+                }
+                catch
+                {
+                    return new JArray();
+                }
             }
 
+            // Se chegamos aqui, temos XML baixado mas não salvo (por erro no salvamento)
             try
             {
-                return JArray.Parse(json);
+                return ConverterXmlParaArray(xml);
             }
             catch
             {
                 return new JArray();
             }
+        }
+
+        private static JArray ConverterXmlParaArray(string xml)
+        {
+            var arr = new JArray();
+            try
+            {
+                var doc = XDocument.Parse(xml);
+                foreach (var post in doc.Descendants("post"))
+                {
+                    var obj = new JObject();
+                    foreach (var el in post.Elements())
+                        obj[el.Name.LocalName] = el.Value;
+                    arr.Add(obj);
+                }
+            }
+            catch
+            {
+                // retorna array vazio em caso de XML malformado
+            }
+            return arr;
         }
 
         private static bool TemInternet()


### PR DESCRIPTION
## Summary
- parse manutencoes feed as XML
- store JSON array converted from XML
- improve error handling for malformed XML or network issues

## Testing
- `msbuild /version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c887495708333813f666338174740