### PR TITLE
Update sync status based on cached JSON

### DIFF
--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -80,10 +80,10 @@ namespace OrganizadorArquivosWPF
             ConfigurarProgressBar();
 
             // Exibe texto-padrão nas labels que serão preenchidas
-            TxtSyncStatus.Text = "Verificando sincronização...";
+            TxtSyncStatus.Text = "Verificando dados de manutenção...";
             TxtSyncStatus.Foreground = Brushes.Gray;
 
-            TxtLastUpdate.Text = "Carregando data do BD...";
+            TxtLastUpdate.Text = "Carregando dados de manutenção...";
             TxtLastUpdate.Foreground = Brushes.Gray;
 
             // Define pasta padrão (pode ser rápido o suficiente para rodar no construtor)
@@ -300,25 +300,22 @@ namespace OrganizadorArquivosWPF
         /// </summary>
         private async Task AtualizarStatusSincronizacaoAsync()
         {
-            bool online = false;
+            bool atualizado = false;
+            DateTime? cacheTime = null;
             try
             {
-                // Se SyncVerifierService.ExcelPath for uma pasta de rede,
-                // o File.Exists já pode demorar. Então rodamos em Task.Run.
-                online = await Task.Run(() => File.Exists(SyncVerifierService.ExcelPath));
+                cacheTime = await Task.Run(() => ManutencoesService.GetCacheTimestamp());
+                atualizado = cacheTime.HasValue && (DateTime.Now - cacheTime.Value).TotalDays < 1;
             }
             catch
             {
-                // Qualquer erro → assume offline
-                online = false;
-                _log.Critical($"BD NÃO ESTÁ ONLINE PARE AGORA");
+                atualizado = false;
             }
 
-            // Atualiza UI no Dispatcher
             Dispatcher.Invoke(() =>
             {
-                TxtSyncStatus.Text = online ? "BD online" : "BD offline";
-                TxtSyncStatus.Foreground = online ? Brushes.LimeGreen : Brushes.Red;
+                TxtSyncStatus.Text = atualizado ? "Dados de manutenção atualizados" : "Dados de manutenção desatualizados";
+                TxtSyncStatus.Foreground = atualizado ? Brushes.LimeGreen : Brushes.Red;
             });
         }
 
@@ -327,47 +324,29 @@ namespace OrganizadorArquivosWPF
         /// </summary>
         private async Task AtualizarDataPlanilhaAsync()
         {
-            string ultima = null;
+            DateTime? cacheTime = null;
             try
             {
-                ultima = await Task.Run(() => _excel.GetLastUpdate());
+                cacheTime = await Task.Run(() => ManutencoesService.GetCacheTimestamp());
             }
             catch (Exception ex)
             {
-                _log.Warning($"Falha ao obter data da base de dados: {ex.Message}");
+                _log.Warning($"Falha ao obter data do cache: {ex.Message}");
             }
 
             Dispatcher.Invoke(() =>
             {
-                if (!string.IsNullOrWhiteSpace(ultima))
+                if (cacheTime.HasValue)
                 {
-                    TxtLastUpdate.Text = $"Última atualização da base de dados: {ultima}";
+                    TxtLastUpdate.Text = $"Última atualização: {cacheTime.Value:dd/MM/yyyy HH:mm}";
                     TxtLastUpdate.Foreground = Brushes.Black;
-                    _log.Info($"Última atualização do base de dados: {ultima}");
-                    if (DateTime.TryParse(ultima, new System.Globalization.CultureInfo("pt-BR"),
-                                          System.Globalization.DateTimeStyles.None, out var dataUltima))
-                    {
-                        if ((DateTime.Now - dataUltima).TotalDays > 2)
-                        {
-                            MessageBox.Show(
-                                "A base de dados não é atualizada há mais de 2 dias.",
-                                "Aviso",
-                                MessageBoxButton.OK,
-                                MessageBoxImage.Error);
-                            _log.Warning($"A base de dados não é atualizada há mais de 2 dias.");
-                        }
-                    }
+                    _log.Info($"Última atualização do cache: {cacheTime.Value}");
                 }
                 else
                 {
-                    TxtLastUpdate.Text = "Última atualização do base de dados: --";
+                    TxtLastUpdate.Text = "Última atualização: --";
                     TxtLastUpdate.Foreground = Brushes.Red;
-                    MessageBox.Show(
-                                "A base de dados não está online",
-                                "Aviso CRITICO",
-                                MessageBoxButton.OK,
-                                MessageBoxImage.Warning);
-                    _log.Warning($"Falha ao obter dados da base de dados, por favor não continue");
+                    _log.Warning("Cache de manutenção não encontrado");
                 }
             });
         }

--- a/OrganizadorArquivosWPF/Services/ManutencoesService.cs
+++ b/OrganizadorArquivosWPF/Services/ManutencoesService.cs
@@ -21,6 +21,26 @@ namespace OrganizadorArquivosWPF.Services
             "manutencoes.json");
 
         /// <summary>
+        /// Caminho para o arquivo em cache contendo o JSON baixado.
+        /// </summary>
+        public static string CacheFilePath => OfflinePath;
+
+        /// <summary>
+        /// Retorna a data de escrita do arquivo de cache ou null se inexistente.
+        /// </summary>
+        public static DateTime? GetCacheTimestamp()
+        {
+            try
+            {
+                return File.Exists(OfflinePath) ? File.GetLastWriteTime(OfflinePath) : (DateTime?)null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Retorna os dados de manutenção. Se houver internet, atualiza o arquivo offline.
         /// </summary>
         public async Task<JArray> ObterDadosAsync()


### PR DESCRIPTION
## Summary
- track maintenance JSON timestamp in `ManutencoesService`
- show maintenance data status in main window instead of spreadsheet status
- tweak loading text for status labels

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8876534c8333914b31822357b89a