### PR TITLE
Fix broken method in ManutencoesService

### DIFF
--- a/OrganizadorArquivosWPF/Services/ManutencoesService.cs
+++ b/OrganizadorArquivosWPF/Services/ManutencoesService.cs
@@ -160,6 +160,8 @@ namespace OrganizadorArquivosWPF.Services
         {
             var arr = await ObterDadosAsync();
             return ParseClientRecords(arr);
+        }
+
         private static JArray ConverterXmlParaArray(string xml)
         {
             var arr = new JArray();


### PR DESCRIPTION
## Summary
- close `ObterClientRecordsAsync` with a proper brace

## Testing
- `dotnet` not installed, so build skipped

------
https://chatgpt.com/codex/tasks/task_e_684d943e31e88333a6623fd3b03bcdd2