### PR TITLE
Improve maintenance data service

### DIFF
--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -41,6 +41,7 @@ namespace OrganizadorArquivosWPF
         private LoggerService _log;
         private RenamerService _renamer;
         private AtualizadorService _update;
+        private ManutencoesService _manutencoes;
         private readonly ObservableCollection<LogEntry> _logs;
         private string _pastaOrigem;
         #endregion
@@ -106,6 +107,7 @@ namespace OrganizadorArquivosWPF
                 var logFileService = new LogFileService();
                 _renamer = new RenamerService(_log, logFileService);
                 _update = new AtualizadorService();
+                _manutencoes = new ManutencoesService();
             });
 
             // 2) Atualiza status de sincronização
@@ -113,6 +115,16 @@ namespace OrganizadorArquivosWPF
 
             // 3) Atualiza data da base de dados
             await AtualizarDataPlanilhaAsync();
+
+            // 4) Baixa dados de manutenção se possível
+            try
+            {
+                await _manutencoes.ObterDadosAsync();
+            }
+            catch (Exception ex)
+            {
+                _log.Warning("Falha ao atualizar dados de manutenção: " + ex.Message);
+            }
         }
 
         #region Botão Processar

--- a/OrganizadorArquivosWPF/OrganizadorArquivosWPF.csproj
+++ b/OrganizadorArquivosWPF/OrganizadorArquivosWPF.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Services\LoggerService.cs" />
     <Compile Include="Services\RenamerService.cs" />
     <Compile Include="Services\SyncVerifierService.cs" />
+    <Compile Include="Services\ManutencoesService.cs" />
     <Compile Include="Views\FallbackWindow.xaml.cs">
       <DependentUpon>FallbackWindow.xaml</DependentUpon>
     </Compile>

--- a/OrganizadorArquivosWPF/Services/ManutencoesService.cs
+++ b/OrganizadorArquivosWPF/Services/ManutencoesService.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace OrganizadorArquivosWPF.Services
+{
+    /// <summary>
+    /// Obtém os dados de manutenção a partir da internet e mantém uma cópia offline em JSON.
+    /// </summary>
+    public class ManutencoesService
+    {
+        private const string ApiUrl = "http://wseletrotransol.service4.sinapi.com.br/dadosbanco.php?action=manutencoes";
+
+        private static readonly string OfflinePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "OneEngRenamer",
+            "manutencoes.json");
+
+        private JArray _dados = new JArray();
+
+        /// <summary>
+        /// Último conjunto de dados obtido.
+        /// </summary>
+        public JArray Dados => _dados;
+
+        /// <summary>
+        /// Retorna os dados de manutenção. Se houver internet, atualiza o arquivo offline.
+        /// </summary>
+        public async Task<JArray> ObterDadosAsync()
+        {
+            string json = null;
+
+            if (TemInternet())
+            {
+                try
+                {
+                    using (var http = new HttpClient())
+                    {
+                        json = await http.GetStringAsync(ApiUrl);
+                        Directory.CreateDirectory(Path.GetDirectoryName(OfflinePath));
+                        File.WriteAllText(OfflinePath, json, Encoding.UTF8);
+                    }
+                }
+                catch
+                {
+                    json = null; // falha na conexão, tenta local
+                }
+            }
+
+            if (json == null)
+            {
+                if (!File.Exists(OfflinePath))
+                    return new JArray();
+
+                json = File.ReadAllText(OfflinePath, Encoding.UTF8);
+            }
+
+            try
+            {
+                _dados = JArray.Parse(json);
+            }
+            catch
+            {
+                _dados = new JArray();
+            }
+
+            return _dados;
+        }
+
+        private static bool TemInternet()
+        {
+            try
+            {
+                using (var client = new WebClient())
+                    client.DownloadString("https://www.bing.com");
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track fetched data in `ManutencoesService`
- log failures when updating maintenance data

## Testing
- `dotnet build OrganizadorArquivosWPF.sln -c Release` *(fails: missing .NET 4.7.2 developer pack)*

------
https://chatgpt.com/codex/tasks/task_e_684c6fc491188333a947ac0aa7b9787d