### PR TITLE
Fix duplicate maintenance download call

### DIFF
--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -131,8 +131,6 @@ namespace OrganizadorArquivosWPF
                 _log.Warning("Falha ao atualizar dados de manutenção: " + ex.Message);
             }
 
-            try { await _manutencoes.ObterDadosAsync(); } catch { }
-
         }
 
         #region Botão Processar


### PR DESCRIPTION
## Summary
- remove redundant `_manutencoes.ObterDadosAsync()` call

## Testing
- `dotnet build OrganizadorArquivosWPF/OrganizadorArquivosWPF.csproj -v minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684da9ec57cc83338018e4c91ad32cc7