### PR TITLE
Implement periodic data updates

### DIFF
--- a/OrganizadorArquivosWPF/App.xaml.cs
+++ b/OrganizadorArquivosWPF/App.xaml.cs
@@ -23,16 +23,19 @@ namespace OrganizadorArquivosWPF
             splash.WindowStartupLocation = WindowStartupLocation.CenterScreen;
             splash.Show();
 
-            // Dispara sincronização em background: não bloqueia a thread de UI
+            // Dispara sincronização e download de dados durante o splash
             var syncTask = Task.Run(() => SyncVerifierService.VerificarOuSincronizarArquivo());
+            try
+            {
+                var manutencao = new ManutencoesService();
+                await manutencao.ObterDadosAsync();
+            }
+            catch
+            {
+                // Ignora falhas de download no splash
+            }
 
-            // Se quiser aguardar a sincronização COMPLETA antes de prosseguir,
-            // descomente a linha abaixo. Caso contrário, já dá pra liberar o login.
-            // await syncTask;
-
-            // Fecha splash após algum tempo ou imediatamente:
-            // - Se você fez await, ele espera terminar; 
-            // - Se não fez await, você pode fechar aqui ou aguardar a Task opcionalmente:
+            // Fecha splash após completar o download
             splash.Close();
             // ------------------------------------------------------
 

--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -94,6 +94,7 @@ namespace OrganizadorArquivosWPF
 
             // Assina evento Loaded para disparar o que é pesado em background
             Loaded += MainWindow_Loaded;
+            Closed += MainWindow_Closed;
         }
 
         /// <summary>
@@ -126,6 +127,7 @@ namespace OrganizadorArquivosWPF
             try
             {
                 await _manutencoes.ObterDadosAsync();
+                _manutencoes.StartAutoUpdate(TimeSpan.FromSeconds(30));
             }
             catch (Exception ex)
             {
@@ -434,6 +436,11 @@ namespace OrganizadorArquivosWPF
         {
             if (_renamer != null && Directory.Exists(_renamer.LastDestination))
                 Process.Start("explorer.exe", _renamer.LastDestination);
+        }
+
+        private void MainWindow_Closed(object sender, EventArgs e)
+        {
+            _manutencoes?.StopAutoUpdate();
         }
         #endregion
     }

--- a/OrganizadorArquivosWPF/Services/ManutencoesService.cs
+++ b/OrganizadorArquivosWPF/Services/ManutencoesService.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OrganizadorArquivosWPF.Models;
 using System.Xml.Linq;
+using System.Timers;
 
 
 namespace OrganizadorArquivosWPF.Services
@@ -26,6 +27,7 @@ namespace OrganizadorArquivosWPF.Services
             "manutencoes.json");
 
         private JArray _dados = new JArray();
+        private Timer _timer;
 
         /// <summary>
         /// Último conjunto de dados obtido.
@@ -196,6 +198,41 @@ namespace OrganizadorArquivosWPF.Services
             catch
             {
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// Inicia a atualização automática dos dados em intervalo fixo.
+        /// </summary>
+        public void StartAutoUpdate(TimeSpan interval)
+        {
+            if (_timer != null)
+                return;
+
+            _timer = new Timer(interval.TotalMilliseconds)
+            {
+                AutoReset = true,
+                Enabled = true
+            };
+            _timer.Elapsed += async (s, e) =>
+            {
+                _timer.Enabled = false;
+                try { await ObterDadosAsync(); }
+                catch { /* ignorar erros de download */ }
+                finally { _timer.Enabled = true; }
+            };
+        }
+
+        /// <summary>
+        /// Para a atualização automática.
+        /// </summary>
+        public void StopAutoUpdate()
+        {
+            if (_timer != null)
+            {
+                _timer.Stop();
+                _timer.Dispose();
+                _timer = null;
             }
         }
     }


### PR DESCRIPTION
## Summary
- start downloading maintenance data during splash screen
- add auto-update timer in `ManutencoesService`
- start periodic download on main window load and stop when closing

## Testing
- `dotnet build OrganizadorArquivosWPF.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685017e446a88333afcb41ed6628b791