### PR TITLE
Improve splash progress and update logging

### DIFF
--- a/OrganizadorArquivosWPF/App.xaml.cs
+++ b/OrganizadorArquivosWPF/App.xaml.cs
@@ -22,13 +22,14 @@ namespace OrganizadorArquivosWPF
             splash.Owner = null;       // para não ficar “presa” a outra janela
             splash.WindowStartupLocation = WindowStartupLocation.CenterScreen;
             splash.Show();
+            var progress = new Progress<int>(p => splash.SetProgress(p));
 
             // Dispara sincronização e download de dados em background
             _ = Task.Run(() => SyncVerifierService.VerificarOuSincronizarArquivo());
             _ = Task.Run(async () =>
             {
                 var manutencao = new ManutencoesService();
-                try { await manutencao.ObterDadosAsync(); } catch { }
+                try { await manutencao.ObterDadosAsync(progress); } catch { }
             });
 
 
@@ -39,7 +40,7 @@ namespace OrganizadorArquivosWPF
             try
             {
                 var manutencao = new ManutencoesService();
-                await manutencao.ObterDadosAsync();
+                await manutencao.ObterDadosAsync(progress);
             }
             catch
             {

--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -70,6 +70,7 @@ namespace OrganizadorArquivosWPF
         private List<ClientRecord> _cachedRecords;
         private readonly ObservableCollection<LogEntry> _logs;
         private readonly DownloadProgress _downloadReporter;
+        private LogEntry _lastUpdateEntry;
         private string _pastaOrigem;
         #endregion
 
@@ -486,10 +487,15 @@ namespace OrganizadorArquivosWPF
         {
             Dispatcher.Invoke(() =>
             {
+                if (_lastUpdateEntry != null)
+                    _logs.Remove(_lastUpdateEntry);
+
                 if (fromInternet)
                     _log.Info($"Dados de manutenção atualizados em {time:HH:mm:ss}");
                 else
                     _log.Warning($"Falha ao atualizar dados de manutenção - usando cache ({time:HH:mm:ss})");
+
+                _lastUpdateEntry = _logs.LastOrDefault();
             });
             _ = AtualizarDataPlanilhaAsync();
         }

--- a/OrganizadorArquivosWPF/Views/SplashWindow.xaml
+++ b/OrganizadorArquivosWPF/Views/SplashWindow.xaml
@@ -18,11 +18,12 @@
             Padding="20"
             SnapsToDevicePixels="True">
         <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
 
             <!-- Texto ou logo central -->
             <StackPanel Grid.Row="0" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0,10,0,10">
@@ -39,19 +40,26 @@
                            HorizontalAlignment="Center" />
             </StackPanel>
 
-            <!-- Texto de status -->
-            <TextBlock Grid.Row="1" 
-                       Text="Sincronizando dados, aguarde..." 
-                       FontSize="14" 
-                       Foreground="#555" 
-                       HorizontalAlignment="Center"
-                       Margin="0,0,0,10"/>
+        <!-- Texto de status -->
+        <TextBlock x:Name="StatusText" Grid.Row="1"
+                   Text="Sincronizando dados, aguarde..."
+                   FontSize="14"
+                   Foreground="#555"
+                   HorizontalAlignment="Center"
+                   Margin="0,0,0,10"/>
 
-            <!-- Barra de progresso indeterminada -->
-            <ProgressBar Grid.Row="2"
-                         IsIndeterminate="True"
-                         Height="20"
-                         Margin="0,0,0,10" />
+        <!-- Barra de progresso -->
+        <ProgressBar x:Name="Progress" Grid.Row="2"
+                     IsIndeterminate="False"
+                     Minimum="0" Maximum="100"
+                     Height="20" Margin="0,0,0,4" />
+
+        <!-- Porcentagem -->
+        <TextBlock x:Name="PercentText" Grid.Row="3"
+                   Text="0%"
+                   FontSize="14"
+                   Foreground="#555"
+                   HorizontalAlignment="Center" />
         </Grid>
     </Border>
 </Window>

--- a/OrganizadorArquivosWPF/Views/SplashWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/Views/SplashWindow.xaml.cs
@@ -11,5 +11,13 @@ namespace OrganizadorArquivosWPF.Views
         {
             InitializeComponent();
         }
+
+        public void SetProgress(int value)
+        {
+            if (value < 0) value = 0;
+            if (value > 100) value = 100;
+            Progress.Value = value;
+            PercentText.Text = $"{value}%";
+        }
     }
 }


### PR DESCRIPTION
## Summary
- show download percentage on the splash screen
- wire splash progress updates via `Progress<int>`
- keep only the latest update log entry in the main window

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685039b269448333a057a6242dee66c0