### PR TITLE
Fix download progress reporting

### DIFF
--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -49,11 +49,20 @@ namespace OrganizadorArquivosWPF
                     {
                         _wnd.DownloadBar.Value = 100;
                         _wnd.DownloadBar.Visibility = Visibility.Collapsed;
+                        _wnd.DownloadBar.IsIndeterminate = false;
+                    }
+                    else if (value < 0)
+                    {
+                        if (_wnd.DownloadBar.Visibility != Visibility.Visible)
+                            _wnd.DownloadBar.Visibility = Visibility.Visible;
+                        _wnd.DownloadBar.IsIndeterminate = true;
+                        _wnd.TxtSyncStatus.Text = "Baixando dados...";
                     }
                     else
                     {
                         if (_wnd.DownloadBar.Visibility != Visibility.Visible)
                             _wnd.DownloadBar.Visibility = Visibility.Visible;
+                        _wnd.DownloadBar.IsIndeterminate = false;
                         _wnd.DownloadBar.Value = value;
                     }
                 });

--- a/OrganizadorArquivosWPF/Services/ManutencoesService.cs
+++ b/OrganizadorArquivosWPF/Services/ManutencoesService.cs
@@ -81,6 +81,8 @@ namespace OrganizadorArquivosWPF.Services
                         response.EnsureSuccessStatusCode();
 
                         var total = response.Content.Headers.ContentLength ?? -1L;
+                        if (total <= 0)
+                            progress?.Report(-1);
                         using (var stream = await response.Content.ReadAsStreamAsync())
                         using (var ms = new MemoryStream())
                         {
@@ -93,6 +95,8 @@ namespace OrganizadorArquivosWPF.Services
                                 readTotal += read;
                                 if (total > 0)
                                     progress?.Report((int)(readTotal * 100 / total));
+                                else
+                                    progress?.Report(-1);
                             }
 
                             xml = Encoding.UTF8.GetString(ms.ToArray());

--- a/OrganizadorArquivosWPF/Views/SplashWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/Views/SplashWindow.xaml.cs
@@ -14,9 +14,17 @@ namespace OrganizadorArquivosWPF.Views
 
         public void SetProgress(int value)
         {
-            if (value < 0) value = 0;
+            if (value < 0)
+            {
+                Progress.IsIndeterminate = true;
+                StatusText.Text = "Baixando dados...";
+                PercentText.Text = string.Empty;
+                return;
+            }
+
+            Progress.IsIndeterminate = false;
             if (value > 100) value = 100;
-            Progress.Value = value;
+            Progress.Value = value < 0 ? 0 : value;
             PercentText.Text = $"{value}%";
         }
     }


### PR DESCRIPTION
## Summary
- show message and indeterminate progress when download size is unknown
- update splash screen progress logic

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503cea489c8333944c510b08ee95d1