### PR TITLE
Add tray service for background updates

### DIFF
--- a/OrganizadorArquivosWPF/App.xaml.cs
+++ b/OrganizadorArquivosWPF/App.xaml.cs
@@ -3,17 +3,21 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
-using OrganizadorArquivosWPF.Models;
+using Microsoft.Win32;
 using OrganizadorArquivosWPF.Services;
+using OrganizadorArquivosWPF.Models;
 using OrganizadorArquivosWPF.Views;
 
 namespace OrganizadorArquivosWPF
 {
     public partial class App : Application
     {
+        private TrayService _tray;
         protected async override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
+
+            EnsureRunAtStartup();
 
             // ------------------------------------------------------
             // (Opcional) 0) Abre splash e executa sincronização
@@ -49,6 +53,9 @@ namespace OrganizadorArquivosWPF
 
             // Fecha splash após completar o download
             splash.Close();
+
+            _tray = new TrayService();
+            _tray.Start(null);
             // ------------------------------------------------------
 
             // ------------------------------------------------------
@@ -81,7 +88,6 @@ namespace OrganizadorArquivosWPF
             // 3) Se não atualizou, continua para a MainWindow
             // ------------------------------------------------------
             var main = new MainWindow(user);
-            main.Closed += (_, __) => Shutdown();
             Current.MainWindow = main;
             main.Show();
 
@@ -114,6 +120,24 @@ namespace OrganizadorArquivosWPF
                 UseShellExecute = true,
                 WorkingDirectory = Path.GetDirectoryName(batPath)
             });
+        }
+
+        private void EnsureRunAtStartup()
+        {
+            try
+            {
+                var runKey = Registry.CurrentUser.OpenSubKey(
+                    "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);
+                var exe = System.Reflection.Assembly.GetExecutingAssembly().Location;
+                runKey?.SetValue("OrganizadorArquivosWPF", '"' + exe + '"');
+            }
+            catch { /* ignore registry errors */ }
+        }
+
+        protected override void OnExit(ExitEventArgs e)
+        {
+            _tray?.Dispose();
+            base.OnExit(e);
         }
     }
 }

--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -130,6 +130,7 @@ namespace OrganizadorArquivosWPF
 
             // Assina evento Loaded para disparar o que é pesado em background
             Loaded += MainWindow_Loaded;
+            Closing += MainWindow_Closing;
             Closed += MainWindow_Closed;
         }
 
@@ -164,7 +165,7 @@ namespace OrganizadorArquivosWPF
             {
                 _manutencoes.UpdateCompleted += Manutencoes_UpdateCompleted;
                 await _manutencoes.ObterDadosAsync(_downloadReporter);
-                _manutencoes.StartAutoUpdate(TimeSpan.FromMinutes(1), _downloadReporter);
+                _manutencoes.StartAutoUpdate(TimeSpan.FromMinutes(5), _downloadReporter);
             }
             catch (Exception ex)
             {
@@ -480,6 +481,12 @@ namespace OrganizadorArquivosWPF
         {
             if (_renamer != null && Directory.Exists(_renamer.LastDestination))
                 Process.Start("explorer.exe", _renamer.LastDestination);
+        }
+
+        private void MainWindow_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            e.Cancel = true;
+            Hide();
         }
 
         private void MainWindow_Closed(object sender, EventArgs e)

--- a/OrganizadorArquivosWPF/OrganizadorArquivosWPF.csproj
+++ b/OrganizadorArquivosWPF/OrganizadorArquivosWPF.csproj
@@ -214,6 +214,7 @@
     <Compile Include="Services\RenamerService.cs" />
     <Compile Include="Services\SyncVerifierService.cs" />
     <Compile Include="Services\ManutencoesService.cs" />
+    <Compile Include="Services\TrayService.cs" />
     <Compile Include="Views\FallbackWindow.xaml.cs">
       <DependentUpon>FallbackWindow.xaml</DependentUpon>
     </Compile>

--- a/OrganizadorArquivosWPF/Services/TrayService.cs
+++ b/OrganizadorArquivosWPF/Services/TrayService.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Drawing;
+using System.Windows;
+using System.Windows.Forms;
+
+namespace OrganizadorArquivosWPF.Services
+{
+    /// <summary>
+    /// Serviço para exibir ícone na bandeja do sistema e manter
+    /// atualização automática em segundo plano.
+    /// </summary>
+    public class TrayService : IDisposable
+    {
+        private readonly NotifyIcon _icon;
+        private readonly ManutencoesService _manutencoes;
+        private readonly TimeSpan _interval = TimeSpan.FromMinutes(5);
+
+        public TrayService()
+        {
+            _manutencoes = new ManutencoesService();
+
+            var icoPath = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ico-app.ico");
+            _icon = new NotifyIcon
+            {
+                Visible = true,
+                Icon = new Icon(icoPath),
+                Text = "Organizador de Arquivos"
+            };
+
+            var menu = new ContextMenuStrip();
+            var openItem = new ToolStripMenuItem("Abrir") { CheckOnClick = false };
+            openItem.Click += (s, e) => Application.Current.MainWindow?.Show();
+            var exitItem = new ToolStripMenuItem("Sair");
+            exitItem.Click += (s, e) => Application.Current.Shutdown();
+            menu.Items.Add(openItem);
+            menu.Items.Add(exitItem);
+            _icon.ContextMenuStrip = menu;
+        }
+
+        public async void Start(IProgress<int> progress)
+        {
+            try { await _manutencoes.ObterDadosAsync(progress); } catch { }
+            _manutencoes.StartAutoUpdate(_interval, progress);
+        }
+
+        public void Dispose()
+        {
+            _icon.Visible = false;
+            _icon.Dispose();
+            _manutencoes.StopAutoUpdate();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `TrayService` to keep a NotifyIcon in the system tray and refresh data every 5 minutes
- start the tray service from `App` and register the app in the Windows startup registry key
- keep the app alive when the main window closes
- update auto‑update interval to five minutes
- include tray service in the project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68505cfcc6e88333b7272efe852df703