### PR TITLE
Fix TrayService event handlers

### DIFF
--- a/OrganizadorArquivosWPF/Services/TrayService.cs
+++ b/OrganizadorArquivosWPF/Services/TrayService.cs
@@ -29,9 +29,9 @@ namespace OrganizadorArquivosWPF.Services
 
             var menu = new ContextMenuStrip();
             var openItem = new ToolStripMenuItem("Abrir") { CheckOnClick = false };
-            openItem.Click += (s, e) => Application.Current.MainWindow?.Show();
+            openItem.Click += (s, e) => System.Windows.Application.Current.MainWindow?.Show();
             var exitItem = new ToolStripMenuItem("Sair");
-            exitItem.Click += (s, e) => Application.Current.Shutdown();
+            exitItem.Click += (s, e) => System.Windows.Application.Current.Shutdown();
             menu.Items.Add(openItem);
             menu.Items.Add(exitItem);
             _icon.ContextMenuStrip = menu;


### PR DESCRIPTION
## Summary
- ensure WPF tray menu references the correct `Application`

## Testing
- `dotnet build OrganizadorArquivosWPF.sln` *(fails: missing .NET Framework reference assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_68505f5aee008333a24e6a69b39e53fb