### PR TITLE
Implement single instance behavior

### DIFF
--- a/OrganizadorArquivosWPF/App.xaml.cs
+++ b/OrganizadorArquivosWPF/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Win32;
@@ -12,9 +13,21 @@ namespace OrganizadorArquivosWPF
 {
     public partial class App : Application
     {
+        private const string MutexName = "OrganizadorArquivosWPF_SingleInstance";
+        private Mutex _mutex;
         private TrayService _tray;
+
         protected async override void OnStartup(StartupEventArgs e)
         {
+            bool created;
+            _mutex = new Mutex(true, MutexName, out created);
+            if (!created)
+            {
+                ActivatePreviousInstance();
+                Shutdown();
+                return;
+            }
+
             base.OnStartup(e);
 
             EnsureRunAtStartup();
@@ -136,8 +149,28 @@ namespace OrganizadorArquivosWPF
 
         protected override void OnExit(ExitEventArgs e)
         {
+            _mutex?.ReleaseMutex();
+            _mutex?.Dispose();
             _tray?.Dispose();
             base.OnExit(e);
+        }
+
+        private static void ActivatePreviousInstance()
+        {
+            var current = Process.GetCurrentProcess();
+            foreach (var process in Process.GetProcessesByName(current.ProcessName))
+            {
+                if (process.Id == current.Id)
+                    continue;
+
+                var handle = process.MainWindowHandle;
+                if (handle != IntPtr.Zero)
+                {
+                    Utils.WindowHelper.ShowWindow(handle, Utils.WindowHelper.SW_RESTORE);
+                    Utils.WindowHelper.SetForegroundWindow(handle);
+                }
+                break;
+            }
         }
     }
 }

--- a/OrganizadorArquivosWPF/OrganizadorArquivosWPF.csproj
+++ b/OrganizadorArquivosWPF/OrganizadorArquivosWPF.csproj
@@ -215,6 +215,7 @@
     <Compile Include="Services\SyncVerifierService.cs" />
     <Compile Include="Services\ManutencoesService.cs" />
     <Compile Include="Services\TrayService.cs" />
+    <Compile Include="Utils\WindowHelper.cs" />
     <Compile Include="Views\FallbackWindow.xaml.cs">
       <DependentUpon>FallbackWindow.xaml</DependentUpon>
     </Compile>

--- a/OrganizadorArquivosWPF/Utils/WindowHelper.cs
+++ b/OrganizadorArquivosWPF/Utils/WindowHelper.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace OrganizadorArquivosWPF.Utils
+{
+    internal static class WindowHelper
+    {
+        [DllImport("user32.dll")]
+        internal static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        internal static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+        internal const int SW_RESTORE = 9;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure only one instance of the application runs
- restore existing window from the tray when starting second instance

## Testing
- `dotnet build OrganizadorArquivosWPF.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68506434f7d0833391b4d15ee8425a25