### PR TITLE
Clear logs after each successful rename

### DIFF
--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -262,6 +262,9 @@ namespace OrganizadorArquivosWPF
                     reporter);
 
                 BtnAbrir.Visibility = Visibility.Visible;
+
+                // Limpa o log visual após concluir a operação com sucesso
+                _log.Clear();
             }
             catch (Exception ex)
             {

--- a/OrganizadorArquivosWPF/Services/LoggerService.cs
+++ b/OrganizadorArquivosWPF/Services/LoggerService.cs
@@ -134,5 +134,13 @@ namespace OrganizadorArquivosWPF.Services
                 }
             }
         }
+
+        /// <summary>
+        /// Limpa todas as entradas de log mantidas em memória e exibidas na UI.
+        /// </summary>
+        public void Clear()
+        {
+            _dispatcher.Invoke(() => _logs.Clear());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a `Clear` helper to `LoggerService`
- clear the log grid after renaming completes successfully

## Testing
- `msbuild OrganizadorArquivosWPF.sln -verbosity:minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506a2037e88333bf93bc43075593af