### PR TITLE
Fix update loop with cached records

### DIFF
--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -506,7 +506,7 @@ namespace OrganizadorArquivosWPF
             }
         }
 
-        private async void Manutencoes_UpdateCompleted(DateTime time, bool fromInternet)
+        private void Manutencoes_UpdateCompleted(DateTime time, bool fromInternet)
         {
             Dispatcher.Invoke(() =>
             {
@@ -523,8 +523,8 @@ namespace OrganizadorArquivosWPF
 
             try
             {
-                // 🔥 Aqui atualiza a base em memória com os dados mais recentes!
-                _cachedRecords = await _manutencoes.ObterClientRecordsAsync(_downloadReporter);
+                // Usa os dados já baixados pelo serviço para evitar recursão do evento
+                _cachedRecords = ManutencoesService.ParseClientRecords(_manutencoes.Dados);
                 _log.Info($"Base de dados atualizada — {_cachedRecords.Count} registros carregados.");
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- avoid calling `ObterClientRecordsAsync` in the update event to prevent recursive events

## Testing
- `msbuild OrganizadorArquivosWPF.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c09b884c8333a0fc43c3b10da47f