### PR TITLE
Improve download messages

### DIFF
--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -50,13 +50,14 @@ namespace OrganizadorArquivosWPF
                         _wnd.DownloadBar.Value = 100;
                         _wnd.DownloadBar.Visibility = Visibility.Collapsed;
                         _wnd.DownloadBar.IsIndeterminate = false;
+                        _wnd.TxtSyncStatus.Text = "Download concluído";
                     }
                     else if (value < 0)
                     {
                         if (_wnd.DownloadBar.Visibility != Visibility.Visible)
                             _wnd.DownloadBar.Visibility = Visibility.Visible;
                         _wnd.DownloadBar.IsIndeterminate = true;
-                        _wnd.TxtSyncStatus.Text = "Baixando dados...";
+                        _wnd.TxtSyncStatus.Text = "Iniciando download...";
                     }
                     else
                     {
@@ -64,6 +65,7 @@ namespace OrganizadorArquivosWPF
                             _wnd.DownloadBar.Visibility = Visibility.Visible;
                         _wnd.DownloadBar.IsIndeterminate = false;
                         _wnd.DownloadBar.Value = value;
+                        _wnd.TxtSyncStatus.Text = $"Baixando dados ({value}%)";
                     }
                 });
             }

--- a/OrganizadorArquivosWPF/Views/SplashWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/Views/SplashWindow.xaml.cs
@@ -17,15 +17,20 @@ namespace OrganizadorArquivosWPF.Views
             if (value < 0)
             {
                 Progress.IsIndeterminate = true;
-                StatusText.Text = "Baixando dados...";
+                StatusText.Text = "Iniciando download...";
                 PercentText.Text = string.Empty;
                 return;
             }
 
             Progress.IsIndeterminate = false;
             if (value > 100) value = 100;
-            Progress.Value = value < 0 ? 0 : value;
+            Progress.Value = value;
             PercentText.Text = $"{value}%";
+
+            if (value >= 100)
+                StatusText.Text = "Download concluído";
+            else
+                StatusText.Text = $"Baixando dados ({value}%)";
         }
     }
 }


### PR DESCRIPTION
## Summary
- clarify download text on splash screen with progress
- update main window download messages for better feedback

## Testing
- `dotnet build OrganizadorArquivosWPF.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c76208cc83338e4890ee5be54ab0