### PR TITLE
Fix status reporting during data download

### DIFF
--- a/OrganizadorArquivosWPF/App.xaml.cs
+++ b/OrganizadorArquivosWPF/App.xaml.cs
@@ -47,12 +47,13 @@ namespace OrganizadorArquivosWPF
             splash.WindowStartupLocation = WindowStartupLocation.CenterScreen;
             splash.Show();
             var progress = new Progress<int>(p => splash.SetProgress(p));
+            var manutencao = new ManutencoesService();
+            manutencao.StatusChanged += msg => splash.TxtStatus.Text = msg;
 
             // Dispara sincronização e download de dados em background
             _ = Task.Run(() => SyncVerifierService.VerificarOuSincronizarArquivo());
             _ = Task.Run(async () =>
             {
-                var manutencao = new ManutencoesService();
                 try { await manutencao.ObterDadosAsync(progress); } catch { }
             });
 
@@ -63,7 +64,6 @@ namespace OrganizadorArquivosWPF
             var syncTask = Task.Run(() => SyncVerifierService.VerificarOuSincronizarArquivo());
             try
             {
-                var manutencao = new ManutencoesService();
                 await manutencao.ObterDadosAsync(progress);
             }
             catch

--- a/OrganizadorArquivosWPF/Services/ManutencoesService.cs
+++ b/OrganizadorArquivosWPF/Services/ManutencoesService.cs
@@ -65,6 +65,8 @@ namespace OrganizadorArquivosWPF.Services
         private readonly Dictionary<string, int> _linhasDinamicas = new Dictionary<string, int>();
         private readonly List<string> _linhasLog = new List<string>();
 
+        public event Action<string> StatusChanged;
+
         private void CriarOuAtualizarLinha(string chave, string texto)
         {
             Application.Current.Dispatcher.InvokeAsync(delegate
@@ -79,7 +81,7 @@ namespace OrganizadorArquivosWPF.Services
                     _linhasLog.Add(texto);
                     _linhasDinamicas[chave] = _linhasLog.Count - 1;
                 }
-                // dispare aqui event/binding para UI observar _linhasLog
+                StatusChanged?.Invoke(texto);
             });
         }
 
@@ -159,9 +161,9 @@ namespace OrganizadorArquivosWPF.Services
                     fromInternet = true;
                     progress?.Report(100);
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // falha momentânea, vai usar cache
+                    StatusChanged?.Invoke($"Erro ao baixar dados: {ex.Message}");
                 }
             }
 
@@ -174,10 +176,11 @@ namespace OrganizadorArquivosWPF.Services
                         : new JArray();
                     progress?.Report(100);
                 }
-                catch
+                catch (Exception ex)
                 {
                     _dados = new JArray();
                     progress?.Report(100);
+                    StatusChanged?.Invoke($"Erro ao carregar cache: {ex.Message}");
                 }
             }
 

--- a/OrganizadorArquivosWPF/Views/SplashWindow.xaml
+++ b/OrganizadorArquivosWPF/Views/SplashWindow.xaml
@@ -41,7 +41,7 @@
             </StackPanel>
 
         <!-- Texto de status -->
-        <TextBlock x:Name="StatusText" Grid.Row="1"
+        <TextBlock x:Name="TxtStatus" Grid.Row="1"
                    Text="Sincronizando dados, aguarde..."
                    FontSize="14"
                    Foreground="#555"

--- a/OrganizadorArquivosWPF/Views/SplashWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/Views/SplashWindow.xaml.cs
@@ -17,7 +17,7 @@ namespace OrganizadorArquivosWPF.Views
             if (value < 0)
             {
                 Progress.IsIndeterminate = true;
-                StatusText.Text = "Iniciando download...";
+                TxtStatus.Text = "Iniciando download...";
                 PercentText.Text = string.Empty;
                 return;
             }
@@ -28,9 +28,9 @@ namespace OrganizadorArquivosWPF.Views
             PercentText.Text = $"{value}%";
 
             if (value >= 100)
-                StatusText.Text = "Download concluído";
+                TxtStatus.Text = "Download concluído";
             else
-                StatusText.Text = $"Baixando dados ({value}%)";
+                TxtStatus.Text = $"Baixando dados ({value}%)";
         }
     }
 }


### PR DESCRIPTION
## Summary
- wire up status updates from `ManutencoesService` so progress messages appear
- rename splash status block to `TxtStatus`
- update splash progress handling

## Testing
- `dotnet build OrganizadorArquivosWPF.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ff552c288333b18b350f13880aef