### PR TITLE
Bugfix tray service

### DIFF
--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -9,13 +9,11 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using Microsoft.Win32;
-using AppForms = System.Windows.Forms.Application;
 using System.Linq;
 using Ookii.Dialogs.Wpf;
 using OrganizadorArquivosWPF.Models;
 using OrganizadorArquivosWPF.Services;
 using OrganizadorArquivosWPF.Views;
-using System.Windows.Forms;
 
 namespace OrganizadorArquivosWPF
 {
@@ -77,7 +75,6 @@ namespace OrganizadorArquivosWPF
         #region Campos e serviços (mais “leves”)
 
         private LoggerService _log;
-        private NotifyIcon _notifyIcon;
         private RenamerService _renamer;
         private AtualizadorService _update;
         private ManutencoesService _manutencoes;
@@ -96,7 +93,6 @@ namespace OrganizadorArquivosWPF
         {
             _usuario = usuario ?? throw new ArgumentNullException(nameof(usuario));
             InitializeComponent();
-            ConfigurarNotifyIcon();
             // Inicializa coleção de logs e serviço de log visual
             _logs = new ObservableCollection<LogEntry>();
             _log = new LoggerService(_logs, Dispatcher);
@@ -384,41 +380,6 @@ namespace OrganizadorArquivosWPF
         }
 
         // ===================== System Tray (Bandeja) ======================
-        private void ConfigurarNotifyIcon()
-        {
-            _notifyIcon = new NotifyIcon
-            {
-                Icon = System.Drawing.Icon.ExtractAssociatedIcon(
-                    System.Reflection.Assembly.GetExecutingAssembly().Location),
-                Visible = true,
-                Text = "Organizador de Arquivos - One Engenharia"
-            };
-
-            // ► Menu da bandeja
-            var contextMenu = new ContextMenuStrip();
-            contextMenu.Items.Add("Restaurar", null, (s, e) => MostrarJanela());
-            contextMenu.Items.Add("Verificar Atualização", null, (s, e) => BtnCheckUpdate_Click(null, null));
-            contextMenu.Items.Add(new ToolStripSeparator());
-            contextMenu.Items.Add("Sair", null, (s, e) => FecharAplicativo());
-
-            _notifyIcon.ContextMenuStrip = contextMenu;
-
-            // ► Clique duplo → Restaurar a janela
-            _notifyIcon.DoubleClick += (s, e) => MostrarJanela();
-        }
-
-        private void MostrarJanela()
-        {
-            Show();
-            WindowState = WindowState.Normal;
-            Activate();
-        }
-
-        private void FecharAplicativo()
-        {
-            _notifyIcon.Visible = false;
-            AppForms.Exit();
-        }
 
 
         /// <summary>

--- a/OrganizadorArquivosWPF/Services/TrayService.cs
+++ b/OrganizadorArquivosWPF/Services/TrayService.cs
@@ -29,9 +29,22 @@ namespace OrganizadorArquivosWPF.Services
 
             var menu = new ContextMenuStrip();
             var openItem = new ToolStripMenuItem("Abrir") { CheckOnClick = false };
-            openItem.Click += (s, e) => System.Windows.Application.Current.MainWindow?.Show();
+            openItem.Click += (s, e) =>
+            {
+                Application.Current?.Dispatcher.Invoke(() =>
+                {
+                    var window = Application.Current.MainWindow;
+                    if (window != null)
+                    {
+                        window.Show();
+                        if (window.WindowState == WindowState.Minimized)
+                            window.WindowState = WindowState.Normal;
+                        window.Activate();
+                    }
+                });
+            };
             var exitItem = new ToolStripMenuItem("Sair");
-            exitItem.Click += (s, e) => System.Windows.Application.Current.Shutdown();
+            exitItem.Click += (s, e) => Application.Current.Shutdown();
             menu.Items.Add(openItem);
             menu.Items.Add(exitItem);
             _icon.ContextMenuStrip = menu;


### PR DESCRIPTION
## Summary
- fix tray service cross-thread open
- remove old tray icon logic from MainWindow

## Testing
- `dotnet build OrganizadorArquivosWPF.sln` *(fails: reference assemblies for .NETFramework,Version=v4.7.2 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574e56ec648333b101ae2cbc0da0f2