### PR TITLE
Fix duplicate download at startup

### DIFF
--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -151,8 +151,8 @@ namespace OrganizadorArquivosWPF
                 _manutencoes = new ManutencoesService();
             });
 
-            // Carrega registros em memória (pode demorar um pouco)
-            _cachedRecords = await _manutencoes.ObterClientRecordsAsync(_downloadReporter);
+            // Carrega rapidamente registros do cache local (sem novo download)
+            _cachedRecords = await Task.Run(() => _manutencoes.LoadCachedRecords());
 
             // 2) Atualiza status de sincronização
             await AtualizarStatusSincronizacaoAsync();


### PR DESCRIPTION
## Summary
- load cached records instead of downloading twice when the main window loads

## Testing
- `dotnet build OrganizadorArquivosWPF.csproj -c Release` *(fails: .NETFramework v4.7.2 reference assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857526496708333889a9117235cc90e