### PR TITLE
Update tray download to show status

### DIFF
--- a/OrganizadorArquivosWPF/MainWindow.xaml.cs
+++ b/OrganizadorArquivosWPF/MainWindow.xaml.cs
@@ -571,6 +571,25 @@ namespace OrganizadorArquivosWPF
             _ = AtualizarDataPlanilhaAsync();
         }
 
+        /// <summary>
+        /// Dispara manualmente o download dos dados de manutenção utilizando
+        /// o mesmo serviço e reporter da janela principal.
+        /// </summary>
+        public async Task BaixarDadosAgoraAsync()
+        {
+            if (_manutencoes == null)
+                return;
+
+            try
+            {
+                await _manutencoes.ObterDadosAsync(_downloadReporter);
+            }
+            catch (Exception ex)
+            {
+                _log.Error($"Erro ao baixar dados manualmente: {ex.Message}");
+            }
+        }
+
 
         #endregion
     }

--- a/OrganizadorArquivosWPF/Services/TrayService.cs
+++ b/OrganizadorArquivosWPF/Services/TrayService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Drawing;
 using System.Windows;
 using System.Windows.Forms;
+using OrganizadorArquivosWPF;
 
 namespace OrganizadorArquivosWPF.Services
 {
@@ -47,10 +48,24 @@ namespace OrganizadorArquivosWPF.Services
                 });
             };
             var downloadItem = new ToolStripMenuItem("Baixar dados agora");
-            downloadItem.Click += async (s, e) =>
+            downloadItem.Click += (s, e) =>
             {
-                try { await _manutencoes.ObterDadosAsync(_progress); }
-                catch (Exception ex) { Console.WriteLine($"[ERRO] Download manual: {ex.Message}"); }
+                var app = System.Windows.Application.Current;
+                if (app != null)
+                {
+                    app.Dispatcher.InvokeAsync(async () =>
+                    {
+                        if (app.MainWindow is MainWindow wnd)
+                        {
+                            await wnd.BaixarDadosAgoraAsync();
+                        }
+                        else
+                        {
+                            try { await _manutencoes.ObterDadosAsync(_progress); }
+                            catch (Exception ex) { Console.WriteLine($"[ERRO] Download manual: {ex.Message}"); }
+                        }
+                    });
+                }
             };
 
             var exitItem = new ToolStripMenuItem("Sair");


### PR DESCRIPTION
## Summary
- expose method to trigger maintenance download from `MainWindow`
- call this method when selecting "Baixar dados agora" from the tray menu so UI status updates

## Testing
- `dotnet build OrganizadorArquivosWPF/OrganizadorArquivosWPF.csproj -v minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685758eb81748333b849d807bba68ae0