### PR TITLE
Improve memory consumption

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -531,7 +531,7 @@ namespace OrganizadorArquivosWPF
                 {
                     // ✅ Sincronizou com sucesso
                     _log.Info($"Dados de manutenção atualizados em {time:HH:mm:ss}");
-                    _cachedRecords = ManutencoesService.ParseClientRecords(_manutencoes.Dados);
+                    _cachedRecords = new List<ClientRecord>(_manutencoes.Records);
                     _log.Info($"Base de dados atualizada — {_cachedRecords.Count} registros carregados.");
                 }
                 else
@@ -546,14 +546,14 @@ namespace OrganizadorArquivosWPF
                     if (cacheVelho)
                     {
                         _log.Critical("Falha ao atualizar dados de manutenção – " + "dados do cache têm mais de 1 dias");
-                        _cachedRecords = ManutencoesService.ParseClientRecords(_manutencoes.Dados);
+                        _cachedRecords = new List<ClientRecord>(_manutencoes.Records);
                         _log.Info($"Base de dados atualizada — {_cachedRecords.Count} registros carregados.");
                     }
                     else
                     {
                         // Cache ainda “fresco”: só um INFO discreto
                         _log.Info($"Sem conexão, usando dados baixados dia ({cacheTime.Value:dd/MM HH:mm})");
-                        _cachedRecords = ManutencoesService.ParseClientRecords(_manutencoes.Dados);
+                        _cachedRecords = new List<ClientRecord>(_manutencoes.Records);
                         _log.Info($"Base de dados atualizada — {_cachedRecords.Count} registros carregados.");
                     }
                 }

--- a/Services/LoggerService.cs
+++ b/Services/LoggerService.cs
@@ -15,6 +15,7 @@ namespace OrganizadorArquivosWPF.Services
         private readonly Dispatcher _dispatcher;
         private readonly object _fileLock = new object();
         private bool _logIoErrorNotified = false;
+        private const int MaxEntries = 500;
 
         public LoggerService(ObservableCollection<LogEntry> logs, Dispatcher dispatcher)
         {
@@ -33,8 +34,13 @@ namespace OrganizadorArquivosWPF.Services
         {
             var entry = new LogEntry(tipo, emoji, mensagem);
 
-            // Atualiza a UI de forma thread-safe
-            _dispatcher.Invoke(() => _logs.Add(entry));
+            // Atualiza a UI de forma thread-safe e limita itens em memória
+            _dispatcher.Invoke(() =>
+            {
+                _logs.Add(entry);
+                if (_logs.Count > MaxEntries)
+                    _logs.RemoveAt(0);
+            });
 
             // Grava em disco de forma thread-safe
             lock (_fileLock)

--- a/Services/ManutencoesService.cs
+++ b/Services/ManutencoesService.cs
@@ -39,12 +39,14 @@ namespace OrganizadorArquivosWPF.Services
         };
 
         private JArray _dados = new JArray();
+        private List<ClientRecord> _records = new List<ClientRecord>();
         private Timer _timer;
         private IProgress<int> _timerProgress;
         private bool _executandoAtualizacao;
 
         public event Action<DateTime, bool> UpdateCompleted;
         public JArray Dados => _dados;
+        public IReadOnlyList<ClientRecord> Records => _records;
         public static string CacheFilePath => OfflinePath;
 
         public static DateTime? GetCacheTimestamp()
@@ -114,6 +116,7 @@ namespace OrganizadorArquivosWPF.Services
                 }
             }
 
+            _records = ParseClientRecords(_dados);
             UpdateCompleted?.Invoke(DateTime.Now, fromInternet);
             return _dados;
         }
@@ -277,14 +280,22 @@ namespace OrganizadorArquivosWPF.Services
         public List<ClientRecord> LoadCachedRecords()
         {
             if (!File.Exists(OfflinePath)) return new List<ClientRecord>();
-            try { return ParseClientRecords(JArray.Parse(File.ReadAllText(OfflinePath, Encoding.UTF8))); }
-            catch { return new List<ClientRecord>(); }
+            try
+            {
+                var list = ParseClientRecords(JArray.Parse(File.ReadAllText(OfflinePath, Encoding.UTF8)));
+                _records = new List<ClientRecord>(list);
+                return list;
+            }
+            catch
+            {
+                return new List<ClientRecord>();
+            }
         }
 
         public async Task<List<ClientRecord>> ObterClientRecordsAsync(IProgress<int> p = null)
         {
-            var arr = await ObterDadosAsync(p);
-            return ParseClientRecords(arr);
+            await ObterDadosAsync(p);
+            return new List<ClientRecord>(_records);
         }
 
         // ======================  UTILIDADES  ==================================


### PR DESCRIPTION
## Summary
- limit LoggerService log collection to 500 entries
- store parsed maintenance records in memory and reuse
- refresh cached records from ManutencoesService

## Testing
- `msbuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685760d98cf88333be8d161671ef9e3c