### PR TITLE
Optimize RAM usage by clearing cached JSON

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -533,6 +533,7 @@ namespace OrganizadorArquivosWPF
                     _log.Info($"Dados de manutenção atualizados em {time:HH:mm:ss}");
                     _cachedRecords = ManutencoesService.ParseClientRecords(_manutencoes.Dados);
                     _log.Info($"Base de dados atualizada — {_cachedRecords.Count} registros carregados.");
+                    _manutencoes.ClearData();
                 }
                 else
                 {
@@ -548,6 +549,7 @@ namespace OrganizadorArquivosWPF
                         _log.Critical("Falha ao atualizar dados de manutenção – " + "dados do cache têm mais de 1 dias");
                         _cachedRecords = ManutencoesService.ParseClientRecords(_manutencoes.Dados);
                         _log.Info($"Base de dados atualizada — {_cachedRecords.Count} registros carregados.");
+                        _manutencoes.ClearData();
                     }
                     else
                     {
@@ -555,6 +557,7 @@ namespace OrganizadorArquivosWPF
                         _log.Info($"Sem conexão, usando dados baixados dia ({cacheTime.Value:dd/MM HH:mm})");
                         _cachedRecords = ManutencoesService.ParseClientRecords(_manutencoes.Dados);
                         _log.Info($"Base de dados atualizada — {_cachedRecords.Count} registros carregados.");
+                        _manutencoes.ClearData();
                     }
                 }
 
@@ -586,6 +589,7 @@ namespace OrganizadorArquivosWPF
             try
             {
                 await _manutencoes.ObterDadosAsync(_downloadReporter);
+                _manutencoes.ClearData();
             }
             catch (Exception ex)
             {

--- a/Services/ManutencoesService.cs
+++ b/Services/ManutencoesService.cs
@@ -347,6 +347,14 @@ namespace OrganizadorArquivosWPF.Services
             _executandoAtualizacao = false;
         }
 
+        /// <summary>
+        /// Libera a memória utilizada pelos dados baixados.
+        /// </summary>
+        public void ClearData()
+        {
+            _dados = null;
+        }
+
     }
 }
 

--- a/Services/TrayService.cs
+++ b/Services/TrayService.cs
@@ -61,7 +61,11 @@ namespace OrganizadorArquivosWPF.Services
                         }
                         else
                         {
-                            try { await _manutencoes.ObterDadosAsync(_progress); }
+                            try
+                            {
+                                await _manutencoes.ObterDadosAsync(_progress);
+                                _manutencoes.ClearData();
+                            }
                             catch (Exception ex) { Console.WriteLine($"[ERRO] Download manual: {ex.Message}"); }
                         }
                     });
@@ -80,7 +84,12 @@ namespace OrganizadorArquivosWPF.Services
         {
 
             _progress = progress;
-            try { await _manutencoes.ObterDadosAsync(progress); } catch { }
+            try
+            {
+                await _manutencoes.ObterDadosAsync(progress);
+                _manutencoes.ClearData();
+            }
+            catch { }
             _manutencoes.StartAutoUpdate(_interval, progress);
         }
 


### PR DESCRIPTION
## Summary
- free JSON cache after parsing to reduce memory usage
- add `ClearData` method in `ManutencoesService`
- clear cached JSON after updates and downloads

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685760d98cf88333be8d161671ef9e3c