### PR TITLE
Add Dropbox backup after maintenance updates

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -78,6 +78,7 @@ namespace OrganizadorArquivosWPF
         private RenamerService _renamer;
         private AtualizadorService _update;
         private ManutencoesService _manutencoes;
+        private BackupService _backup;
         private List<ClientRecord> _cachedRecords;
         private readonly ObservableCollection<LogEntry> _logs;
         private readonly DownloadProgress _downloadReporter;
@@ -149,6 +150,7 @@ namespace OrganizadorArquivosWPF
                 _renamer = new RenamerService(_log, logFileService);
                 _update = new AtualizadorService();
                 _manutencoes = new ManutencoesService();
+                _backup = new BackupService();
             });
 
             // Carrega rapidamente registros do cache local (sem novo download)
@@ -563,6 +565,13 @@ namespace OrganizadorArquivosWPF
 
                 _lastUpdateEntry = _logs.LastOrDefault();
             });
+
+            if (fromInternet && _backup != null && _renamer != null &&
+                !string.IsNullOrWhiteSpace(_renamer.LastDestination) &&
+                Directory.Exists(_renamer.LastDestination))
+            {
+                _ = _backup.EnviarBackupAsync(_renamer.LastDestination);
+            }
 
             try
             {

--- a/OrganizadorArquivosWPF.csproj
+++ b/OrganizadorArquivosWPF.csproj
@@ -218,6 +218,7 @@
     <Compile Include="Services\SyncVerifierService.cs" />
     <Compile Include="Services\ManutencoesService.cs" />
     <Compile Include="Services\TrayService.cs" />
+    <Compile Include="Services\BackupService.cs" />
     <Compile Include="Utils\WindowHelper.cs" />
     <Compile Include="Views\FallbackWindow.xaml.cs">
       <DependentUpon>FallbackWindow.xaml</DependentUpon>

--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using Dropbox.Api;
+using Dropbox.Api.Files;
+
+namespace OrganizadorArquivosWPF.Services
+{
+    /// <summary>
+    /// Serviço simples para enviar backups para o Dropbox.
+    /// </summary>
+    public class BackupService
+    {
+        private const string AppKey = "523wx0kknv1xj4h";
+        private const string AppSecret = "mcw1pgyfnx3hqbh";
+        private const string RefreshToken = "7-G0mKVNMRQAAAAAAAAAASvMELHHomwEkmVR24HK-XLEFvNMpNUp7Py0hxUnjic_";
+        private const string DropboxFolder = "/backups";
+
+        private async Task<string> ObterAccessTokenAsync()
+        {
+            var tokenService = new GerarTokenService(AppKey, AppSecret, RefreshToken);
+            return await tokenService.ObterAccessTokenAsync();
+        }
+
+        /// <summary>
+        /// Compacta a pasta indicada e envia para o Dropbox.
+        /// </summary>
+        public async Task EnviarBackupAsync(string pasta)
+        {
+            if (string.IsNullOrWhiteSpace(pasta) || !Directory.Exists(pasta))
+                return;
+
+            string nomeZip = DateTime.Now.ToString("yyyyMMdd_HHmmss") + ".zip";
+            string zipLocal = Path.Combine(Path.GetTempPath(), nomeZip);
+
+            try
+            {
+                if (File.Exists(zipLocal))
+                    File.Delete(zipLocal);
+
+                ZipFile.CreateFromDirectory(pasta, zipLocal, CompressionLevel.Optimal, false);
+
+                string token = await ObterAccessTokenAsync();
+                using (var dbx = new DropboxClient(token))
+                using (var fs = File.OpenRead(zipLocal))
+                {
+                    string dropboxPath = DropboxFolder + "/" + nomeZip;
+                    await dbx.Files.UploadAsync(dropboxPath, WriteMode.Overwrite.Instance, body: fs);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[ERRO] Falha ao enviar backup: {ex.Message}");
+            }
+            finally
+            {
+                try { if (File.Exists(zipLocal)) File.Delete(zipLocal); } catch { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `BackupService` for uploading zipped folders to Dropbox
- initialize BackupService in MainWindow
- trigger backup upload whenever maintenance data is updated
- include new service file in project

## Testing
- `dotnet --version` *(fails: command not found)*
- `msbuild /version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685763dc02ac8333ad622ad1c9096769