### PR TITLE
Implement backup operation using renamer logic

### DIFF
--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -4,6 +4,7 @@ using System.IO.Compression;
 using System.Threading.Tasks;
 using Dropbox.Api;
 using Dropbox.Api.Files;
+using OrganizadorArquivosWPF.Models;
 
 namespace OrganizadorArquivosWPF.Services
 {
@@ -58,6 +59,41 @@ namespace OrganizadorArquivosWPF.Services
             {
                 try { if (File.Exists(zipLocal)) File.Delete(zipLocal); } catch { }
             }
+        }
+
+        /// <summary>
+        /// Executa o mesmo processo do <see cref="RenamerService"/>, salvando o
+        /// resultado localmente e opcionalmente enviando para o Dropbox.
+        /// </summary>
+        public async Task ProcessarBackupAsync(
+            string pastaOrigem,
+            ClientRecord registro,
+            string sistema,
+            string tipoSistema,
+            string destinoLocal,
+            bool enviarParaNuvem,
+            string nomeFuncionario,
+            string matriculaFuncionario,
+            IProgress<int> progress = null)
+        {
+            if (string.IsNullOrWhiteSpace(pastaOrigem) || !Directory.Exists(pastaOrigem))
+                throw new DirectoryNotFoundException("Pasta de origem inválida para backup.");
+
+            var logFileService = new LogFileService();
+            var renamer = new RenamerService(_log, logFileService);
+            await renamer.RenameAsync(
+                pastaOrigem,
+                registro,
+                sistema,
+                tipoSistema,
+                true,
+                destinoLocal,
+                nomeFuncionario,
+                matriculaFuncionario,
+                progress);
+
+            if (enviarParaNuvem)
+                await EnviarBackupAsync(renamer.LastDestination);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add new `ProcessarBackupAsync` method to run the renamer workflow and optionally upload to Dropbox

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685824befe9c8333a3e68157e52cfc1a