### PR TITLE
Add splash before update check

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -37,8 +37,14 @@ namespace OrganizadorArquivosWPF
             base.OnStartup(e);
             EnsureRunAtStartup();
 
+            var splash = new SplashWindow();
+            splash.Show();
+
             _tray = new TrayService();
-            await Task.Run(() => _tray.Start(null)); // <-- await real aqui
+            var progress = new Progress<int>(v => splash.SetProgress(v));
+            await _tray.StartAsync(progress);
+
+            splash.Close();
 
             // Prompt de atualização
             var updatePrompt = new UpdatePromptWindow();

--- a/Services/TrayService.cs
+++ b/Services/TrayService.cs
@@ -81,7 +81,7 @@ namespace OrganizadorArquivosWPF.Services
             _icon.ContextMenuStrip = menu;
         }
 
-        public async void Start(IProgress<int> progress)
+        public async Task StartAsync(IProgress<int> progress)
         {
 
             _progress = progress;


### PR DESCRIPTION
## Summary
- start splash screen before checking for updates
- convert TrayService.Start to StartAsync for proper awaiting

## Testing
- `dotnet build OrganizadorArquivosWPF.csproj -c Release` *(fails: reference assemblies for .NETFramework v4.7.2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594a9875808333aff86ba60f785d03