### PR TITLE
Evita download duplicado na Main

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -166,8 +166,19 @@ namespace OrganizadorArquivosWPF
             try
             {
                 _manutencoes.UpdateCompleted += Manutencoes_UpdateCompleted;
-                await _manutencoes.ObterDadosAsync(_downloadReporter);
-                _manutencoes.StartAutoUpdate(TimeSpan.FromMinutes(5), _downloadReporter);
+
+                // Se o download inicial já foi realizado pela SplashScreen
+                // (através do TrayService), evitamos repetir a operação aqui.
+                DateTime? cacheTime = ManutencoesService.GetCacheTimestamp();
+                bool cacheRecente =
+                    cacheTime.HasValue &&
+                    (DateTime.Now - cacheTime.Value).TotalMinutes < 10;
+
+                if (!cacheRecente)
+                    await _manutencoes.ObterDadosAsync(_downloadReporter);
+
+                // Inicia o auto-update para rodar a cada 10 minutos
+                _manutencoes.StartAutoUpdate(TimeSpan.FromMinutes(10), _downloadReporter);
             }
             catch (Exception ex)
             {

--- a/Services/TrayService.cs
+++ b/Services/TrayService.cs
@@ -15,7 +15,10 @@ namespace OrganizadorArquivosWPF.Services
     {
         private readonly NotifyIcon _icon;
         private readonly ManutencoesService _manutencoes;
-        private readonly TimeSpan _interval = TimeSpan.FromMinutes(5);
+        // Intervalo padrão para atualizações automáticas
+        // A primeira sincronização já ocorre na tela splash. Por isso, a
+        // próxima tentativa de download só deve acontecer após 10 minutos.
+        private readonly TimeSpan _interval = TimeSpan.FromMinutes(10);
         private IProgress<int> _progress;
         private LoggerService _log => LoggerService.Instance;
 


### PR DESCRIPTION
## Summary
- evita baixar dados novamente quando a tela principal abre
- agenda o auto-update para cada 10 minutos

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594e280e8c833383a84d35bd8c4e5b