### PR TITLE
Handle missing login gracefully

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -59,17 +59,13 @@ namespace OrganizadorArquivosWPF
             // Login
             var login = new LoginWindow();
             bool? loginOk = login.ShowDialog();
-            if (loginOk != true)
+            if (loginOk == true)
             {
-                Shutdown();
-                return;
+                UsuarioRecord user = login.Usuario;
+                var main = new MainWindow(user);
+                Current.MainWindow = main;
+                main.Show();
             }
-
-            UsuarioRecord user = login.Usuario;
-
-            var main = new MainWindow(user);
-            Current.MainWindow = main;
-            main.Show();
         }
 
 

--- a/Services/TrayService.cs
+++ b/Services/TrayService.cs
@@ -42,14 +42,27 @@ namespace OrganizadorArquivosWPF.Services
             {
                 System.Windows.Application.Current?.Dispatcher.Invoke(() =>
                 {
-                    var window = System.Windows.Application.Current.MainWindow;
-                    if (window != null)
+                    var app = System.Windows.Application.Current;
+                    if (app == null)
+                        return;
+
+                    var window = app.MainWindow;
+                    if (window == null)
                     {
-                        window.Show();
-                        if (window.WindowState == WindowState.Minimized)
-                            window.WindowState = WindowState.Normal;
-                        window.Activate();
+                        var login = new Views.LoginWindow();
+                        if (login.ShowDialog() == true)
+                        {
+                            var main = new MainWindow(login.Usuario);
+                            app.MainWindow = main;
+                            main.Show();
+                        }
+                        return;
                     }
+
+                    window.Show();
+                    if (window.WindowState == WindowState.Minimized)
+                        window.WindowState = WindowState.Normal;
+                    window.Activate();
                 });
             };
             var downloadItem = new ToolStripMenuItem("Baixar dados agora");


### PR DESCRIPTION
## Summary
- keep running if the user cancels login
- open the login window from tray when necessary

## Testing
- `xbuild /p:Configuration=Release` *(fails: missing NormalizePath)*

------
https://chatgpt.com/codex/tasks/task_e_6859553617508333999ce40f40cd280e