### PR TITLE
Fix version detection on self-contained builds

### DIFF
--- a/Services/AtualizadorService.cs
+++ b/Services/AtualizadorService.cs
@@ -20,10 +20,23 @@ namespace OrganizadorArquivosWPF.Services
         {
             // 1) Versão local
             Version localVer = new Version(0, 0, 0, 0);
+            // A partir da versão com .NET 8 self-contained o executável é
+            // apenas um host nativo e a DLL contém os metadados reais.
+            var dllPath = Path.Combine(InstallDir, "OrganizadorArquivosWPF.dll");
             var exePath = Path.Combine(InstallDir, "OrganizadorArquivosWPF.exe");
-            if (File.Exists(exePath))
+
+            string asmPath = File.Exists(dllPath) ? dllPath : exePath;
+
+            if (File.Exists(asmPath))
             {
-                localVer = AssemblyName.GetAssemblyName(exePath).Version;
+                try
+                {
+                    localVer = AssemblyName.GetAssemblyName(asmPath).Version;
+                }
+                catch (BadImageFormatException)
+                {
+                    // Executável não possui metadados (ex: host nativo). Mantém versão padrão.
+                }
             }
 
             // 2) Versão remota


### PR DESCRIPTION
## Summary
- handle scenario where executable is a native host
- check DLL before EXE when reading local version

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c07472bf88333ae7a42504003922d