### PR TITLE
Reduce auto-update log spam

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -542,37 +542,34 @@ namespace OrganizadorArquivosWPF
                 if (_lastUpdateEntry != null)
                     _logs.Remove(_lastUpdateEntry);
 
+                string mensagem;
                 if (fromInternet)
                 {
-                    // ✅ Sincronizou com sucesso
-                    _log.Info($"Dados de manutenção atualizados em {time:HH:mm:ss}");
                     _cachedRecords = new List<ClientRecord>(_manutencoes.Records);
-                    _log.Info($"Base de dados atualizada — {_cachedRecords.Count} registros carregados.");
+                    mensagem = $"Dados de manutenção atualizados em {time:HH:mm:ss} — {_cachedRecords.Count} registros carregados.";
                     _manutencoes.ClearData();
+                    _log.Info(mensagem);
                 }
                 else
                 {
-                    // ❌ Falhou – decide se avisa ou não, conforme “idade” do cache
                     DateTime? cacheTime = ManutencoesService.GetCacheTimestamp();
-
                     bool cacheVelho =
                         !cacheTime.HasValue ||
                         (DateTime.Now - cacheTime.Value).TotalDays >= 1;
 
+                    _cachedRecords = new List<ClientRecord>(_manutencoes.Records);
+
                     if (cacheVelho)
                     {
-                        _log.Critical("Falha ao atualizar dados de manutenção – " + "dados do cache têm mais de 1 dias");
-                        _cachedRecords = new List<ClientRecord>(_manutencoes.Records);
-                        _log.Info($"Base de dados atualizada — {_cachedRecords.Count} registros carregados.");
+                        mensagem = $"Falha ao atualizar dados de manutenção – dados do cache têm mais de 1 dias — {_cachedRecords.Count} registros.";
                         _manutencoes.ClearData();
+                        _log.Critical(mensagem);
                     }
                     else
                     {
-                        // Cache ainda “fresco”: só um INFO discreto
-                        _log.Info($"Sem conexão, usando dados baixados dia ({cacheTime.Value:dd/MM HH:mm})");
-                        _cachedRecords = new List<ClientRecord>(_manutencoes.Records);
-                        _log.Info($"Base de dados atualizada — {_cachedRecords.Count} registros carregados.");
+                        mensagem = $"Sem conexão, usando dados baixados dia ({cacheTime.Value:dd/MM HH:mm}) — {_cachedRecords.Count} registros.";
                         _manutencoes.ClearData();
+                        _log.Info(mensagem);
                     }
                 }
 

--- a/Models/LogEntry.cs
+++ b/Models/LogEntry.cs
@@ -1,13 +1,66 @@
-﻿using System;
+using System;
+using System.ComponentModel;
 
 namespace OrganizadorArquivosWPF.Models
 {
-    public class LogEntry
+    public class LogEntry : INotifyPropertyChanged
     {
-        public DateTime Hora { get; set; }
-        public string Tipo { get; set; }
-        public string Emoji { get; set; }
-        public string Mensagem { get; set; }
+        private DateTime _hora;
+        private string _tipo;
+        private string _emoji;
+        private string _mensagem;
+
+        public DateTime Hora
+        {
+            get => _hora;
+            set
+            {
+                if (_hora != value)
+                {
+                    _hora = value;
+                    OnPropertyChanged(nameof(Hora));
+                }
+            }
+        }
+
+        public string Tipo
+        {
+            get => _tipo;
+            set
+            {
+                if (_tipo != value)
+                {
+                    _tipo = value;
+                    OnPropertyChanged(nameof(Tipo));
+                }
+            }
+        }
+
+        public string Emoji
+        {
+            get => _emoji;
+            set
+            {
+                if (_emoji != value)
+                {
+                    _emoji = value;
+                    OnPropertyChanged(nameof(Emoji));
+                }
+            }
+        }
+
+        public string Mensagem
+        {
+            get => _mensagem;
+            set
+            {
+                if (_mensagem != value)
+                {
+                    _mensagem = value;
+                    OnPropertyChanged(nameof(Mensagem));
+                }
+            }
+        }
 
         public LogEntry(string tipo, string emoji, string mensagem)
         {
@@ -16,5 +69,10 @@ namespace OrganizadorArquivosWPF.Models
             Emoji = emoji;
             Mensagem = mensagem;
         }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyChanged(string propertyName)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 }

--- a/Services/ManutencoesService.cs
+++ b/Services/ManutencoesService.cs
@@ -339,9 +339,7 @@ namespace OrganizadorArquivosWPF.Services
 
                 try
                 {
-                    _log.Info("🔄 Auto-update iniciado…");
                     await ObterDadosAsync(_timerProgress);
-                    _log.Info("✅ Auto-update concluído.");
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary
- implement property change notification in `LogEntry`
- condense log output on maintenance update
- stop logging auto-update start and end messages

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5258cf3c83339111efb9d0d20a85