### PR TITLE
Add document fallback when no MT/AC folder

### DIFF
--- a/Services/RenamerService.cs
+++ b/Services/RenamerService.cs
@@ -99,6 +99,15 @@ namespace OrganizadorArquivosWPF.Services
             // Se existir exatamente uma, retorna direto
             if (candidatas.Length == 1) return candidatas[0];
 
+            // Se nenhuma pasta foi encontrada, usa Documentos como base
+            if (candidatas.Length == 0)
+            {
+                var docs = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+                var fallback = Path.Combine(docs, "OrganizadorArquivos");
+                Directory.CreateDirectory(fallback);
+                return fallback;
+            }
+
             // Caso contrário, pergunta ao usuário (InputBox já provê a UX esperada)
             int escolha = 0;
             while (escolha < 1 || escolha > 100)


### PR DESCRIPTION
## Summary
- fallback to Documents folder if RenamerService can't find MT or AC paths

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c57fb89008333b6d401a731bb9bfa