### PR TITLE
Replace outdated batch updater with UpdateCompiller.exe

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -51,7 +51,7 @@ namespace OrganizadorArquivosWPF
             bool? wantsUpdate = updatePrompt.ShowDialog();
             if (wantsUpdate == true && updatePrompt.ShouldUpdate)
             {
-                RunUpdaterBat();
+                RunUpdaterExe();
                 Shutdown();
                 return;
             }
@@ -69,26 +69,26 @@ namespace OrganizadorArquivosWPF
         }
 
 
-        private void RunUpdaterBat()
+        private void RunUpdaterExe()
         {
-            string batPath = Path.Combine(
+            string exePath = Path.Combine(
                 AppDomain.CurrentDomain.BaseDirectory,
                 "win-x64",
-                "AtualizadorSilencioso.bat");
+                "UpdateCompiller.exe");
 
-            if (!File.Exists(batPath))
+            if (!File.Exists(exePath))
             {
                 MessageBox.Show(
-                    $"Arquivo de atualização não encontrado:\n{batPath}",
+                    $"Arquivo de atualização não encontrado:\n{exePath}",
                     "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
             Process.Start(new ProcessStartInfo
             {
-                FileName = batPath,
+                FileName = exePath,
                 UseShellExecute = true,
-                WorkingDirectory = Path.GetDirectoryName(batPath)
+                WorkingDirectory = Path.GetDirectoryName(exePath)
             });
         }
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -465,21 +465,21 @@ namespace OrganizadorArquivosWPF
 
         private async Task RunUpdateAsync()
         {
-            var batPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
+            var exePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
                                        "win-x64",
-                                       "AtualizadorSilencioso.bat");
-            if (!File.Exists(batPath))
+                                       "UpdateCompiller.exe");
+            if (!File.Exists(exePath))
             {
-                System.Windows.MessageBox.Show($"Arquivo de atualização não encontrado:\n{batPath}",
+                System.Windows.MessageBox.Show($"Arquivo de atualização não encontrado:\n{exePath}",
                                 "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
             Process.Start(new ProcessStartInfo
             {
-                FileName = batPath,
+                FileName = exePath,
                 UseShellExecute = true,
-                WorkingDirectory = Path.GetDirectoryName(batPath)
+                WorkingDirectory = Path.GetDirectoryName(exePath)
             });
 
             await Task.Delay(500);


### PR DESCRIPTION
## Summary
- change update routine to launch **UpdateCompiller.exe**
- rename helper method to `RunUpdaterExe`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5c22f16483338a3a3cd30501739a