### PR TITLE
Improve backup skip logging

### DIFF
--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -30,6 +30,7 @@ public class BackupService
 
     private readonly GraphServiceClient _graph;
     private readonly LoggerService _log = LoggerService.Instance;
+    private readonly HashSet<string> _skipLogged = new(StringComparer.OrdinalIgnoreCase);
     private string? _driveId;
 
     public BackupService()
@@ -134,7 +135,8 @@ public class BackupService
         var enviados = CarregarHistorico(BackupHistoryFile);
         if (enviados.Contains(numOs))
         {
-            _log.Info($"Backup já enviado para a O.S {numOs}. Pulando envio.");
+            if (_skipLogged.Add(numOs))
+                _log.Info($"Backup já enviado para a O.S {numOs}. Pulando envio.");
             return;
         }
 


### PR DESCRIPTION
## Summary
- avoid logging duplicate 'backup already sent' messages

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6288f87c8333904db59e7a8e18b7