### PR TITLE
Adiciona download da planilha na splash

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -44,6 +44,11 @@ namespace OrganizadorArquivosWPF
             var progress = new Progress<int>(v => splash.SetProgress(v));
             await _tray.StartAsync(progress);
 
+            splash.SetStatus("Baixando planilha de funcionários...");
+            splash.SetProgress(-1);
+            var funcService = new FuncionariosService();
+            await Task.Run(() => funcService.ListarTodos());
+
             splash.Close();
 
             // Prompt de atualização

--- a/Views/SplashWindow.xaml.cs
+++ b/Views/SplashWindow.xaml.cs
@@ -12,6 +12,11 @@ namespace OrganizadorArquivosWPF.Views
             InitializeComponent();
         }
 
+        public void SetStatus(string text)
+        {
+            TxtStatus.Text = text;
+        }
+
         public void SetProgress(int value)
         {
             if (value < 0)


### PR DESCRIPTION
## Summary
- add a method in the splash window to update status text
- download the employee spreadsheet before closing the splash screen

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d40ee5f408333b450c67a3fef36d0