### PR TITLE
Save versao.txt during splash screen

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -10,6 +10,7 @@ using IWshRuntimeLibrary;
 using OrganizadorArquivosWPF.Services;
 using OrganizadorArquivosWPF.Models;
 using OrganizadorArquivosWPF.Views;
+using OrganizadorArquivosWPF.Helpers;
 
 namespace OrganizadorArquivosWPF
 {
@@ -49,6 +50,9 @@ namespace OrganizadorArquivosWPF
             splash.SetProgress(-1);
             var funcService = new FuncionariosService();
             await Task.Run(() => funcService.ListarTodos());
+
+            // Salva versão antes de seguir para o prompt de atualização
+            Versao.GravarVersaoEmTxt();
 
             splash.Close();
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -98,7 +98,6 @@ namespace OrganizadorArquivosWPF
         {
             _usuario = usuario ?? throw new ArgumentNullException(nameof(usuario));
             InitializeComponent();
-            Versao.GravarVersaoEmTxt();
             // Inicializa coleção de logs e serviço de log visual
             _logs = new ObservableCollection<LogEntry>();
             _log = new LoggerService(_logs, Dispatcher);


### PR DESCRIPTION
## Summary
- record the application version into `versao.txt` while the splash screen is shown
- remove the later call in the main window

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d48fbb5a883338beddb0689ed976d