### PR TITLE
Fix startup registry path

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -108,7 +108,9 @@ namespace OrganizadorArquivosWPF
             {
                 var runKey = Registry.CurrentUser.OpenSubKey(
                     "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);
-                var exe = System.Reflection.Assembly.GetExecutingAssembly().Location;
+                var exe = Environment.ProcessPath ??
+                          System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName ??
+                          System.Reflection.Assembly.GetExecutingAssembly().Location;
                 runKey?.SetValue("OrganizadorArquivosWPF", '"' + exe + '"');
                 runKey?.Close();
 


### PR DESCRIPTION
## Summary
- fix path for Windows startup entry by using `Environment.ProcessPath` to ensure the EXE path is stored

## Testing
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4f02ea288333a0dfbe321cadfe00