### PR TITLE
Implement manual mode for zero OS

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -221,37 +221,46 @@ namespace OrganizadorArquivosWPF
             var osNum = osInput;
             var fullOS = uf + osNum;
 
-            _log.Info("Buscando na base de dados…");
+            bool manualMode = osNum.Length > 0 && osNum.All(c => c == '0');
+
+            _log.Info(manualMode ? "Modo manual ativado." : "Buscando na base de dados…");
 
             ClientRecord record;
-            try
+            if (!manualMode)
             {
-                record = await Task.Run(() =>
+                try
                 {
-                    int total = _cachedRecords.Count;
-                    for (int i = 0; i < total; i++)
+                    record = await Task.Run(() =>
                     {
-                        reporter.Report((int)((i + 1) * 100.0 / total));
-                        var r = _cachedRecords[i];
-                        if (r.NumOS.Equals(fullOS, StringComparison.OrdinalIgnoreCase))
-                            return r;
-                    }
-                    return null;
-                });
+                        int total = _cachedRecords.Count;
+                        for (int i = 0; i < total; i++)
+                        {
+                            reporter.Report((int)((i + 1) * 100.0 / total));
+                            var r = _cachedRecords[i];
+                            if (r.NumOS.Equals(fullOS, StringComparison.OrdinalIgnoreCase))
+                                return r;
+                        }
+                        return null;
+                    });
+                }
+                catch (Exception ex)
+                {
+                    _log.Error($"Erro ao ler base de dados: {ex.Message}");
+                    System.Windows.MessageBox.Show($"Erro ao ler base de dados: {ex.Message}",
+                                    "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
+                    ToggleUIBusy(false);
+                    return;
+                }
             }
-            catch (Exception ex)
+            else
             {
-                _log.Error($"Erro ao ler base de dados: {ex.Message}");
-                System.Windows.MessageBox.Show($"Erro ao ler base de dados: {ex.Message}",
-                                "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
-                ToggleUIBusy(false);
-                return;
+                record = null;
             }
 
             if (record == null)
             {
                 _log.Warning("OS não encontrada – solicitando dados manuais…");
-                record = await MostrarFallbackAsync(fullOS, uf);
+                record = await MostrarFallbackAsync(fullOS, uf, manualMode);
                 if (record == null)
                 {
                     ToggleUIBusy(false);
@@ -300,7 +309,7 @@ namespace OrganizadorArquivosWPF
             }
         }
 
-        private Task<ClientRecord> MostrarFallbackAsync(string fullOS, string uf)
+        private Task<ClientRecord> MostrarFallbackAsync(string fullOS, string uf, bool allowAnyId = false)
         {
             // Chamamos ShowDialog de forma síncrona, mas todo o trabalho de GetRouteList() 
             // (pesado) pode rodar em background antes de abrir a janela.
@@ -317,7 +326,7 @@ namespace OrganizadorArquivosWPF
                 // Precisamos chamar ShowDialog na thread de UI → Dispatcher.Invoke
                 Dispatcher.Invoke(() =>
                 {
-                    var fb = new FallbackWindow(fullOS, rotaList, uf, _cachedRecords) { Owner = this };
+                    var fb = new FallbackWindow(fullOS, rotaList, uf, _cachedRecords, allowAnyId) { Owner = this };
                     if (fb.ShowDialog() == true)
                     {
                         fallbackResult = new ClientRecord

--- a/Views/FallbackWindow.xaml.cs
+++ b/Views/FallbackWindow.xaml.cs
@@ -26,13 +26,20 @@ namespace OrganizadorArquivosWPF.Views
 
         // Conjunto de registros carregados em memória
         private readonly IList<ClientRecord> _records;
+        // Indica que o ID pode ser digitado livremente (sem busca)
+        private readonly bool _allowAnyId;
 
-        public FallbackWindow(string osFull, IEnumerable<string> rotas, string uf, IEnumerable<ClientRecord> records)
+        public FallbackWindow(string osFull,
+                              IEnumerable<string> rotas,
+                              string uf,
+                              IEnumerable<ClientRecord> records,
+                              bool allowAnyId = false)
         {
             InitializeComponent();
 
             OSFull = osFull;
             _ufPrefixo = uf.ToUpperInvariant();
+            _allowAnyId = allowAnyId;
             _records = records?.ToList() ?? new List<ClientRecord>();
 
             TxtOSFull.Text = osFull;
@@ -41,7 +48,8 @@ namespace OrganizadorArquivosWPF.Views
             foreach (var r in rotas.Distinct().OrderBy(x => x))
                 CmbRota.Items.Add(new ComboBoxItem { Content = r });
 
-            CmbRota.IsEnabled = false; // rota será preenchida automaticamente
+            // Quando em modo manual, a rota deve ser escolhida manualmente
+            CmbRota.IsEnabled = !allowAnyId;
 
             // Prefixa o campo IdSIGFI com a UF
             TxtIdSigfi.Text = _ufPrefixo;
@@ -49,19 +57,30 @@ namespace OrganizadorArquivosWPF.Views
 
             // Inicialmente nenhum cliente, valida botão OK
             ClienteEncontrado = null;
+            if (_allowAnyId)
+                LblCliente.Content = "Modo manual - cliente não verificado.";
             Validate();
 
             // Concluiu a inicialização
             _carregando = false;
         }
 
-        // Habilita OK apenas quando ID SIGFI estiver completo e cliente existir
+        // Habilita OK apenas quando ID SIGFI estiver completo.
+        // Em modo normal exige cliente encontrado; em modo manual exige rota selecionada.
         private void Validate()
         {
-            BtnOk.IsEnabled =
+            bool idValido =
                 !string.IsNullOrWhiteSpace(TxtIdSigfi.Text) &&
-                TxtIdSigfi.Text.Length > _ufPrefixo.Length &&
-                !string.IsNullOrEmpty(ClienteEncontrado);
+                TxtIdSigfi.Text.Length > _ufPrefixo.Length;
+
+            if (_allowAnyId)
+            {
+                BtnOk.IsEnabled = idValido && CmbRota.SelectedIndex > 0;
+            }
+            else
+            {
+                BtnOk.IsEnabled = idValido && !string.IsNullOrEmpty(ClienteEncontrado);
+            }
         }
 
         // Busca assincrona sem travar UI
@@ -128,7 +147,15 @@ namespace OrganizadorArquivosWPF.Views
         }
 
         private void CmbRota_Changed(object sender, SelectionChangedEventArgs e)
-            => Validate();
+        {
+            if (_allowAnyId)
+            {
+                var item = CmbRota.SelectedItem as ComboBoxItem;
+                Rota = item?.Content.ToString();
+            }
+
+            Validate();
+        }
 
         private async void TxtIdSigfi_TextChanged(object sender, TextChangedEventArgs e)
         {
@@ -145,7 +172,8 @@ namespace OrganizadorArquivosWPF.Views
                 ClienteEncontrado = null;
                 LblCliente.Content = "Digite o restante do ID SIGFI.";
                 Rota = string.Empty;
-                CmbRota.SelectedIndex = -1;
+                if (!_allowAnyId)
+                    CmbRota.SelectedIndex = -1;
                 Validate();
                 return;
             }
@@ -156,14 +184,24 @@ namespace OrganizadorArquivosWPF.Views
                 ClienteEncontrado = null;
                 LblCliente.Content = "ID SIGFI incompleto (mínimo 5 dígitos).";
                 Rota = string.Empty;
-                CmbRota.SelectedIndex = -1;
+                if (!_allowAnyId)
+                    CmbRota.SelectedIndex = -1;
                 Validate();
                 return;
             }
 
-            // Quando cumprido o mínimo, inicia busca assíncrona
-            Validate(); // enquanto busca, OK permanece desabilitado
-            await BuscarClientePorIdSigfiAsync(texto);
+            // Quando cumprido o mínimo, inicia busca assíncrona (modo normal)
+            if (_allowAnyId)
+            {
+                LblCliente.Content = "Modo manual - cliente não verificado.";
+                ClienteEncontrado = null;
+                Validate();
+            }
+            else
+            {
+                Validate(); // enquanto busca, OK permanece desabilitado
+                await BuscarClientePorIdSigfiAsync(texto);
+            }
         }
 
         private void Chk160_Checked(object sender, RoutedEventArgs e)
@@ -176,6 +214,11 @@ namespace OrganizadorArquivosWPF.Views
         {
             // Lê valores finais
             IdSigfi = TxtIdSigfi.Text.Trim();
+            if (_allowAnyId)
+            {
+                var item = CmbRota.SelectedItem as ComboBoxItem;
+                Rota = item?.Content.ToString();
+            }
             DialogResult = true;
         }
 


### PR DESCRIPTION
## Summary
- trigger manual mode if OS input consists only of zeroes
- allow manual ID SIGFI entry without database lookup
- support manual route selection when manual mode is enabled

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eba50ae188333a60c0b67627299b9