### PR TITLE
Add configuration class for Graph credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# OrganizadorArquivosWPF
+
+This application interacts with Microsoft Graph and requires Azure AD credentials.
+
+## Configuration
+
+Credentials are read from the environment or an optional `config.json` file placed next to the executable. Set the following environment variables (or provide the same keys in `config.json`):
+
+- `TENANT_ID` – Azure Active Directory tenant ID
+- `CLIENT_ID` – Application (client) ID
+- `CLIENT_SECRET` – Application secret
+
+Example `config.json`:
+
+```json
+{
+  "TENANT_ID": "00000000-0000-0000-0000-000000000000",
+  "CLIENT_ID": "00000000-0000-0000-0000-000000000000",
+  "CLIENT_SECRET": "your-secret"
+}
+```
+
+Environment variables take precedence over values from the configuration file.

--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -17,9 +17,6 @@ namespace OrganizadorArquivosWPF.Services;
 
 public class BackupService
 {
-    private const string TenantId = "3b08e64e-b3be-402b-bb26-1fa4f91cf61f";
-    private const string ClientId = "3cffac6a-f9d9-42d1-9065-4054fcd40163";
-    private const string ClientSecret = "JFd8Q~hHgTYYo0P0EjAM8mpe3xm3.5vTfCHRFc.T";
 
     private const string SPDomain = "oneengenharia.sharepoint.com";
     private const string SPSitePath = "OneEngenharia";
@@ -32,7 +29,7 @@ public class BackupService
     public BackupService()
     {
         var scopes = new[] { "https://graph.microsoft.com/.default" };
-        var credential = new ClientSecretCredential(TenantId, ClientId, ClientSecret);
+        var credential = new ClientSecretCredential(Config.TenantId, Config.ClientId, Config.ClientSecret);
         _graph = new GraphServiceClient(credential, scopes);
     }
 

--- a/Services/Config.cs
+++ b/Services/Config.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace OrganizadorArquivosWPF.Services
+{
+    /// <summary>
+    /// Provides access to application configuration values.
+    /// Values are read from environment variables or an optional
+    /// <c>config.json</c> file located next to the executable.
+    /// </summary>
+    public static class Config
+    {
+        private static readonly Dictionary<string, string>? _fileSettings;
+
+        public static readonly string TenantId;
+        public static readonly string ClientId;
+        public static readonly string ClientSecret;
+
+        static Config()
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "config.json");
+            if (File.Exists(path))
+            {
+                try
+                {
+                    var json = File.ReadAllText(path);
+                    _fileSettings = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+                }
+                catch
+                {
+                    // ignore malformed config file
+                }
+            }
+
+            TenantId = GetSetting("TENANT_ID");
+            ClientId = GetSetting("CLIENT_ID");
+            ClientSecret = GetSetting("CLIENT_SECRET");
+        }
+
+        private static string GetSetting(string key)
+        {
+            var value = Environment.GetEnvironmentVariable(key);
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+
+            if (_fileSettings != null && _fileSettings.TryGetValue(key, out var fromFile) && !string.IsNullOrWhiteSpace(fromFile))
+                return fromFile;
+
+            throw new InvalidOperationException($"Configuration value '{key}' not found.");
+        }
+    }
+}

--- a/Services/FuncionariosService.cs
+++ b/Services/FuncionariosService.cs
@@ -17,9 +17,6 @@ namespace OrganizadorArquivosWPF.Services
 
     public class FuncionariosService
     {
-        private const string TenantId = "3b08e64e-b3be-402b-bb26-1fa4f91cf61f";
-        private const string ClientId = "3cffac6a-f9d9-42d1-9065-4054fcd40163";
-        private const string ClientSecret = "JFd8Q~hHgTYYo0P0EjAM8mpe3xm3.5vTfCHRFc.T";
 
         private const string SPDomain = "oneengenharia.sharepoint.com";
         private const string SPSitePath = "OneEngenharia";
@@ -36,7 +33,7 @@ namespace OrganizadorArquivosWPF.Services
         public FuncionariosService()
         {
             var scopes = new[] { "https://graph.microsoft.com/.default" };
-            var credential = new ClientSecretCredential(TenantId, ClientId, ClientSecret);
+            var credential = new ClientSecretCredential(Config.TenantId, Config.ClientId, Config.ClientSecret);
             _graph = new GraphServiceClient(credential, scopes);
         }
 

--- a/Services/ManutencoesService.cs
+++ b/Services/ManutencoesService.cs
@@ -20,9 +20,6 @@ namespace OrganizadorArquivosWPF.Services
 {
     public class ManutencoesService
     {
-        private const string TenantId = "3b08e64e-b3be-402b-bb26-1fa4f91cf61f";
-        private const string ClientId = "3cffac6a-f9d9-42d1-9065-4054fcd40163";
-        private const string ClientSecret = "JFd8Q~hHgTYYo0P0EjAM8mpe3xm3.5vTfCHRFc.T";
 
         private const string SPDomain = "oneengenharia.sharepoint.com";
         private const string SPSitePath = "OneEngenharia";
@@ -55,7 +52,7 @@ namespace OrganizadorArquivosWPF.Services
         public ManutencoesService()
         {
             var scopes = new[] { "https://graph.microsoft.com/.default" };
-            var credential = new ClientSecretCredential(TenantId, ClientId, ClientSecret);
+            var credential = new ClientSecretCredential(Config.TenantId, Config.ClientId, Config.ClientSecret);
             _graph = new GraphServiceClient(credential, scopes);
             _log?.Info("ManutencoesService inicializado");
         }


### PR DESCRIPTION
## Summary
- create `Config` class that reads credentials from environment variables or config.json
- use `Config` in `BackupService`, `ManutencoesService`, and `FuncionariosService`
- document required variables in `README`

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d9a7266c8333ad94770757f0c6f8