### PR TITLE
Remove config file dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,12 @@ This application interacts with Microsoft Graph and requires Azure AD credential
 
 ## Configuration
 
-Credentials are read from the environment or an optional `config.json` file placed next to the executable. Set the following environment variables (or provide the same keys in `config.json`):
+Credentials are read from environment variables. Set the following variables:
 
 - `TENANT_ID` – Azure Active Directory tenant ID
 - `CLIENT_ID` – Application (client) ID
 - `CLIENT_SECRET` – Application secret
 
-Example `config.json`:
-
-```json
-{
-  "TENANT_ID": "00000000-0000-0000-0000-000000000000",
-  "CLIENT_ID": "00000000-0000-0000-0000-000000000000",
-  "CLIENT_SECRET": "your-secret"
-}
-```
-
-Environment variables take precedence over values from the configuration file.
 OrganizadorArquivosWPF is a Windows Presentation Foundation (WPF) desktop application used by One Engenharia LTDA to organize engineering files. It automates tasks such as renaming, moving and backing up documents to cloud storage.
 
 ## Prerequisites

--- a/Services/Config.cs
+++ b/Services/Config.cs
@@ -1,18 +1,14 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text.Json;
+
 
 namespace OrganizadorArquivosWPF.Services
 {
     /// <summary>
     /// Provides access to application configuration values.
-    /// Values are read from environment variables or an optional
-    /// <c>config.json</c> file located next to the executable.
+    /// Values are read from environment variables.
     /// </summary>
     public static class Config
     {
-        private static readonly Dictionary<string, string>? _fileSettings;
 
         public static readonly string TenantId;
         public static readonly string ClientId;
@@ -20,20 +16,6 @@ namespace OrganizadorArquivosWPF.Services
 
         static Config()
         {
-            var path = Path.Combine(AppContext.BaseDirectory, "config.json");
-            if (File.Exists(path))
-            {
-                try
-                {
-                    var json = File.ReadAllText(path);
-                    _fileSettings = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-                }
-                catch
-                {
-                    // ignore malformed config file
-                }
-            }
-
             TenantId = GetSetting("TENANT_ID");
             ClientId = GetSetting("CLIENT_ID");
             ClientSecret = GetSetting("CLIENT_SECRET");
@@ -44,9 +26,6 @@ namespace OrganizadorArquivosWPF.Services
             var value = Environment.GetEnvironmentVariable(key);
             if (!string.IsNullOrWhiteSpace(value))
                 return value;
-
-            if (_fileSettings != null && _fileSettings.TryGetValue(key, out var fromFile) && !string.IsNullOrWhiteSpace(fromFile))
-                return fromFile;
 
             throw new InvalidOperationException($"Configuration value '{key}' not found.");
         }


### PR DESCRIPTION
## Summary
- use environment variables only for configuration
- simplify configuration documentation

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862dcdf8c9883339446d865e22b79de