### PR TITLE
Add installation file lookup for manual SIGFI

### DIFF
--- a/Models/InstalacaoRecord.cs
+++ b/Models/InstalacaoRecord.cs
@@ -1,0 +1,12 @@
+namespace OrganizadorArquivosWPF.Models
+{
+    /// <summary>
+    /// Representa um registro do arquivo de instalações.
+    /// </summary>
+    public class InstalacaoRecord
+    {
+        public string IdServicosConj { get; set; }
+        public string NomeDoCliente { get; set; }
+        public string Rota { get; set; }
+    }
+}

--- a/Services/InstalacaoService.cs
+++ b/Services/InstalacaoService.cs
@@ -1,0 +1,131 @@
+using Azure.Identity;
+using Microsoft.Graph;
+using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using OrganizadorArquivosWPF.Models;
+
+namespace OrganizadorArquivosWPF.Services
+{
+    public class InstalacaoService
+    {
+        private const string SiteId = "03b55b3a-5e43-430f-90db-687ed2c5b32f";
+        private const string ListId = "eeee4abc-d931-4f12-b88b-747d024baf7f";
+
+        private static readonly string OfflinePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "OneEngRenamer",
+            "instalacao.json");
+
+        private readonly GraphServiceClient _graph;
+        private string _driveId;
+        private static LoggerService _log => LoggerService.Instance;
+
+        public InstalacaoService()
+        {
+            var scopes = new[] { "https://graph.microsoft.com/.default" };
+            var credential = new ClientSecretCredential(Config.TenantId, Config.ClientId, Config.ClientSecret);
+            _graph = new GraphServiceClient(credential, scopes);
+        }
+
+        private async Task<string> ObterDriveIdAsync()
+        {
+            if (!string.IsNullOrEmpty(_driveId))
+                return _driveId;
+
+            try
+            {
+                var drive = await _graph
+                    .Sites[SiteId]
+                    .Lists[ListId]
+                    .Drive
+                    .GetAsync();
+
+                if (drive == null || string.IsNullOrEmpty(drive.Id))
+                    throw new Exception("A lista não retornou um Drive válido.");
+
+                _driveId = drive.Id;
+                return _driveId;
+            }
+            catch (Exception ex)
+            {
+                _log?.Error($"Erro ao obter Drive ID: {ex.Message}");
+                throw;
+            }
+        }
+
+        private async Task BaixarArquivoAsync()
+        {
+            string driveId = await ObterDriveIdAsync();
+
+            var page = await _graph
+                .Drives[driveId]
+                .Items["root"]
+                .Children
+                .GetAsync();
+
+            var meta = page.Value
+                .Where(it => it.File != null && it.Name.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                .Where(it => it.Name.Contains("Instalacao_AC", StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(it => it.LastModifiedDateTime)
+                .FirstOrDefault();
+
+            if (meta == null)
+                throw new FileNotFoundException("Arquivo de instalação não encontrado no SharePoint.");
+
+            using var stream = await _graph.Drives[driveId].Items[meta.Id].Content.GetAsync();
+            Directory.CreateDirectory(Path.GetDirectoryName(OfflinePath));
+            using var reader = new StreamReader(stream);
+            File.WriteAllText(OfflinePath, await reader.ReadToEndAsync());
+        }
+
+        private void GarantirArquivoLocal()
+        {
+            if (!File.Exists(OfflinePath))
+            {
+                try
+                {
+                    BaixarArquivoAsync().GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    throw new FileNotFoundException("Arquivo de instalação não encontrado e não foi possível baixar do SharePoint.", ex);
+                }
+            }
+        }
+
+        public (string NomeCliente, string Rota)? BuscarPorIdSigfi(string idSigfi)
+        {
+            if (string.IsNullOrWhiteSpace(idSigfi))
+                return null;
+
+            GarantirArquivoLocal();
+
+            try
+            {
+                var json = File.ReadAllText(OfflinePath);
+                var root = JObject.Parse(json);
+                var arr = root["instalacoes"] as JArray;
+                if (arr == null) return null;
+
+                foreach (var item in arr.OfType<JObject>())
+                {
+                    var val = item.Value<string>("IDSERVICOSCONJ");
+                    if (string.Equals(val, idSigfi, StringComparison.OrdinalIgnoreCase))
+                    {
+                        string cliente = item.Value<string>("NOMEDOCLIENTE") ?? string.Empty;
+                        string rota = item.Value<string>("ROTA") ?? string.Empty;
+                        return (cliente, rota);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _log?.Error($"Erro ao ler arquivo de instalação: {ex.Message}");
+            }
+            return null;
+        }
+    }
+}

--- a/Views/FallbackWindow.xaml.cs
+++ b/Views/FallbackWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using OrganizadorArquivosWPF.Models;
+using OrganizadorArquivosWPF.Services;
 
 namespace OrganizadorArquivosWPF.Views
 {
@@ -28,6 +29,7 @@ namespace OrganizadorArquivosWPF.Views
         private readonly IList<ClientRecord> _records;
         // Indica que o ID pode ser digitado livremente (sem busca)
         private readonly bool _allowAnyId;
+        private readonly InstalacaoService _instalacaoService = new InstalacaoService();
 
         public FallbackWindow(string osFull,
                               IEnumerable<string> rotas,
@@ -190,11 +192,52 @@ namespace OrganizadorArquivosWPF.Views
                 return;
             }
 
-            // Quando cumprido o mínimo, inicia busca assíncrona (modo normal)
+            // Quando cumprido o mínimo, inicia busca assíncrona
             if (_allowAnyId)
             {
-                LblCliente.Content = "Modo manual - cliente não verificado.";
-                ClienteEncontrado = null;
+                Validate();
+                LblCliente.Content = "Buscando cliente...";
+                try
+                {
+                    var resultado = await Task.Run(() => _instalacaoService.BuscarPorIdSigfi(texto));
+                    if (resultado.HasValue)
+                    {
+                        ClienteEncontrado = resultado.Value.NomeCliente;
+                        LblCliente.Content = $"Cliente: {ClienteEncontrado}";
+                        var rotaEncontrada = resultado.Value.Rota;
+                        Rota = rotaEncontrada;
+                        bool achou = false;
+                        foreach (ComboBoxItem item in CmbRota.Items)
+                        {
+                            if (string.Equals(item.Content.ToString(), rotaEncontrada, StringComparison.OrdinalIgnoreCase))
+                            {
+                                CmbRota.SelectedItem = item;
+                                achou = true;
+                                break;
+                            }
+                        }
+                        if (!achou && !string.IsNullOrEmpty(rotaEncontrada))
+                        {
+                            var novo = new ComboBoxItem { Content = rotaEncontrada };
+                            CmbRota.Items.Add(novo);
+                            CmbRota.SelectedItem = novo;
+                        }
+                    }
+                    else
+                    {
+                        ClienteEncontrado = null;
+                        LblCliente.Content = "Cliente não encontrado.";
+                        Rota = string.Empty;
+                        CmbRota.SelectedIndex = -1;
+                    }
+                }
+                catch
+                {
+                    ClienteEncontrado = null;
+                    LblCliente.Content = "Erro ao buscar cliente.";
+                    Rota = string.Empty;
+                    CmbRota.SelectedIndex = -1;
+                }
                 Validate();
             }
             else


### PR DESCRIPTION
## Summary
- add `InstalacaoRecord` model
- implement `InstalacaoService` to download and query installation data
- use `InstalacaoService` in `FallbackWindow` to resolve client name when manual SIGFI mode is active

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fa006aa88333bf54ff7a8d06f81c