### PR TITLE
Update install file download logic

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -638,7 +638,9 @@ namespace OrganizadorArquivosWPF
             try
             {
                 var downloadTask = _manutencoes.ObterDadosAsync(_downloadReporter);
-                await Task.WhenAll(downloadTask, backupTask);
+                var instService = new InstalacaoService();
+                var instalacaoTask = instService.AtualizarArquivoAsync();
+                await Task.WhenAll(downloadTask, instalacaoTask, backupTask);
                 _manutencoes.ClearData();
 
                 if (backupTask.Status == TaskStatus.RanToCompletion)

--- a/Services/InstalacaoService.cs
+++ b/Services/InstalacaoService.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Timers;
 using OrganizadorArquivosWPF.Models;
 
 namespace OrganizadorArquivosWPF.Services
@@ -21,6 +22,7 @@ namespace OrganizadorArquivosWPF.Services
 
         private readonly GraphServiceClient _graph;
         private string _driveId;
+        private Timer _timer;
         private static LoggerService _log => LoggerService.Instance;
 
         public InstalacaoService()
@@ -79,6 +81,37 @@ namespace OrganizadorArquivosWPF.Services
             Directory.CreateDirectory(Path.GetDirectoryName(OfflinePath));
             using var reader = new StreamReader(stream);
             File.WriteAllText(OfflinePath, await reader.ReadToEndAsync());
+        }
+
+        /// <summary>
+        /// Baixa o arquivo de instalação do SharePoint substituindo
+        /// qualquer versão local existente.
+        /// </summary>
+        public async Task AtualizarArquivoAsync()
+        {
+            try
+            {
+                await BaixarArquivoAsync();
+            }
+            catch (Exception ex)
+            {
+                _log?.Warning($"Erro ao atualizar arquivo de instalação: {ex.Message}");
+            }
+        }
+
+        public void StartAutoUpdate(TimeSpan interval)
+        {
+            if (_timer != null) return;
+            _timer = new Timer(interval.TotalMilliseconds) { AutoReset = true, Enabled = true };
+            _timer.Elapsed += async (s, e) => await AtualizarArquivoAsync();
+        }
+
+        public void StopAutoUpdate()
+        {
+            if (_timer == null) return;
+            _timer.Stop();
+            _timer.Dispose();
+            _timer = null;
         }
 
         private void GarantirArquivoLocal()

--- a/Services/TrayService.cs
+++ b/Services/TrayService.cs
@@ -15,6 +15,7 @@ namespace OrganizadorArquivosWPF.Services
     {
         private readonly NotifyIcon _icon;
         private readonly ManutencoesService _manutencoes;
+        private readonly InstalacaoService _instalacao;
         // Intervalo padrão para atualizações automáticas
         // A primeira sincronização já ocorre na tela splash. Por isso, a
         // próxima tentativa de download só deve acontecer após 10 minutos.
@@ -25,6 +26,7 @@ namespace OrganizadorArquivosWPF.Services
         public TrayService()
         {
             _manutencoes = new ManutencoesService();
+            _instalacao = new InstalacaoService();
 
             var icoPath = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ico-app.ico");
             _icon = new NotifyIcon
@@ -83,6 +85,7 @@ namespace OrganizadorArquivosWPF.Services
                             {
                                 await _manutencoes.ObterDadosAsync(_progress);
                                 _manutencoes.ClearData();
+                                await _instalacao.AtualizarArquivoAsync();
                             }
                             catch (Exception ex) { _log.Error($"Download manual: {ex.Message}"); }
                         }
@@ -112,9 +115,11 @@ namespace OrganizadorArquivosWPF.Services
             {
                 await _manutencoes.ObterDadosAsync(progress);
                 _manutencoes.ClearData();
+                await _instalacao.AtualizarArquivoAsync();
             }
             catch { }
             _manutencoes.StartAutoUpdate(_interval, progress);
+            _instalacao.StartAutoUpdate(_interval);
         }
 
         public void Dispose()
@@ -122,6 +127,7 @@ namespace OrganizadorArquivosWPF.Services
             _icon.Visible = false;
             _icon.Dispose();
             _manutencoes.StopAutoUpdate();
+            _instalacao.StopAutoUpdate();
         }
     }
 }


### PR DESCRIPTION
## Summary
- download install file via `InstalacaoService` during splash initialization and periodic syncs
- expose `InstalacaoService` auto-update API
- invoke install file download on manual sync

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fc7915608333accb7a70ab8e7ff4