### PR TITLE
Improve download progress

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -11,6 +11,7 @@ using OrganizadorArquivosWPF.Services;
 using OrganizadorArquivosWPF.Models;
 using OrganizadorArquivosWPF.Views;
 using OrganizadorArquivosWPF.Helpers;
+using OrganizadorArquivosWPF.Utils;
 
 namespace OrganizadorArquivosWPF
 {
@@ -43,16 +44,26 @@ namespace OrganizadorArquivosWPF
             splash.Show();
 
             _tray = new TrayService();
-            var progress = new Progress<int>(v => splash.SetProgress(v));
+            var baseProgress = new Progress<int>(v => splash.SetProgress(v));
+
+            // 4 arquivos de manutenção + instalação + funcionários
+            var multi = new Utils.MultiProgress(baseProgress, 6);
+            var trayProgress = multi.NextSegment(5);
+            var funcProgress = multi.NextSegment();
 
             // Executa downloads em paralelo e limita o tempo de espera
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
-            var trayTask = _tray.StartAsync(progress).WaitAsync(cts.Token);
+            var trayTask = _tray.StartAsync(trayProgress).WaitAsync(cts.Token);
 
             splash.SetStatus("Baixando planilha de funcionários...");
-            splash.SetProgress(-1);
+            funcProgress.Report(-1);
             var funcService = new FuncionariosService();
-            var funcTask = Task.Run(() => funcService.ListarTodos(), cts.Token);
+            var funcTask = Task.Run(() =>
+            {
+                var list = funcService.ListarTodos();
+                funcProgress.Report(100);
+                return list;
+            }, cts.Token);
 
             try
             {

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -15,6 +15,7 @@ using OrganizadorArquivosWPF.Models;
 using OrganizadorArquivosWPF.Services;
 using OrganizadorArquivosWPF.Views;
 using OrganizadorArquivosWPF.Helpers;
+using OrganizadorArquivosWPF.Utils;
 
 namespace OrganizadorArquivosWPF
 {
@@ -637,9 +638,34 @@ namespace OrganizadorArquivosWPF
 
             try
             {
-                var downloadTask = _manutencoes.ObterDadosAsync(_downloadReporter);
+                var mp = new Utils.MultiProgress(_downloadReporter, 6); // 4 manutenções + instalação + uploads
+                var manutProg = mp.NextSegment(4);
+                var instProg = mp.NextSegment();
+                var uploadProg = mp.NextSegment();
+
+                var downloadTask = _manutencoes.ObterDadosAsync(manutProg);
                 var instService = new InstalacaoService();
-                var instalacaoTask = instService.AtualizarArquivoAsync();
+                instProg.Report(-1);
+                var instalacaoTask = Task.Run(async () =>
+                {
+                    await instService.AtualizarArquivoAsync();
+                    instProg.Report(100);
+                });
+
+                if (backupTask != null && backupTask.Status != TaskStatus.Created)
+                {
+                    uploadProg.Report(-1);
+                    backupTask = backupTask.ContinueWith(t =>
+                    {
+                        uploadProg.Report(100);
+                        return t.Result;
+                    });
+                }
+                else
+                {
+                    uploadProg.Report(100);
+                }
+
                 await Task.WhenAll(downloadTask, instalacaoTask, backupTask);
                 _manutencoes.ClearData();
 

--- a/Services/TrayService.cs
+++ b/Services/TrayService.cs
@@ -109,16 +109,24 @@ namespace OrganizadorArquivosWPF.Services
 
         public async Task StartAsync(IProgress<int> progress)
         {
-
             _progress = progress;
+
+            var multi = new Utils.MultiProgress(progress, 5); // 4 arquivos de manutenção + instalação
+            var manutProg = multi.NextSegment(4);
+            var instProg = multi.NextSegment();
+
             try
             {
-                await _manutencoes.ObterDadosAsync(progress);
+                await _manutencoes.ObterDadosAsync(manutProg);
                 _manutencoes.ClearData();
+
+                instProg.Report(-1);
                 await _instalacao.AtualizarArquivoAsync();
+                instProg.Report(100);
             }
             catch { }
-            _manutencoes.StartAutoUpdate(_interval, progress);
+
+            _manutencoes.StartAutoUpdate(_interval);
             _instalacao.StartAutoUpdate(_interval);
         }
 

--- a/Utils/MultiProgress.cs
+++ b/Utils/MultiProgress.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace OrganizadorArquivosWPF.Utils
+{
+    /// <summary>
+    /// Helper para dividir uma barra de progresso em segmentos.
+    /// Cada segmento recebe parte proporcional do progresso total.
+    /// </summary>
+    public class MultiProgress
+    {
+        private readonly IProgress<int> _baseProgress;
+        private readonly double _totalUnits;
+        private double _consumed;
+
+        public MultiProgress(IProgress<int> progress, int totalUnits)
+        {
+            if (totalUnits <= 0)
+                throw new ArgumentOutOfRangeException(nameof(totalUnits));
+            _baseProgress = progress ?? throw new ArgumentNullException(nameof(progress));
+            _totalUnits = totalUnits;
+        }
+
+        /// <summary>
+        /// Cria um segmento com peso relativo informado.
+        /// </summary>
+        public IProgress<int> NextSegment(int units = 1)
+        {
+            if (units <= 0)
+                throw new ArgumentOutOfRangeException(nameof(units));
+            double start = (_consumed / _totalUnits) * 100.0;
+            double range = (units / _totalUnits) * 100.0;
+            _consumed += units;
+            return new Progress<int>(value =>
+            {
+                if (value < 0)
+                {
+                    _baseProgress.Report(value);
+                    return;
+                }
+                value = Math.Clamp(value, 0, 100);
+                double scaled = start + (value / 100.0) * range;
+                _baseProgress.Report((int)Math.Round(scaled));
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `MultiProgress` helper for splitting progress into segments
- use `MultiProgress` in splash screen startup to cover maintenance, installation and employees downloads
- apply progress slices in tray service
- track installation and upload steps during manual sync

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fee45b5c8333bd21e73d07d5077a