### PR TITLE
Improve download progress

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -44,15 +44,17 @@ namespace OrganizadorArquivosWPF
 
             _tray = new TrayService();
             var progress = new Progress<int>(v => splash.SetProgress(v));
+            var tracker = new Utils.ProgressTracker(progress, 2);
 
             // Executa downloads em paralelo e limita o tempo de espera
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
-            var trayTask = _tray.StartAsync(progress).WaitAsync(cts.Token);
+            var trayTask = _tray.StartAsync(tracker.NextSegment()).WaitAsync(cts.Token);
 
             splash.SetStatus("Baixando planilha de funcionários...");
             splash.SetProgress(-1);
             var funcService = new FuncionariosService();
-            var funcTask = Task.Run(() => funcService.ListarTodos(), cts.Token);
+            var funcSeg = tracker.NextSegment();
+            var funcTask = Task.Run(() => { funcService.ListarTodos(); funcSeg.Report(100); }, cts.Token);
 
             try
             {

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -637,10 +637,13 @@ namespace OrganizadorArquivosWPF
 
             try
             {
-                var downloadTask = _manutencoes.ObterDadosAsync(_downloadReporter);
+                var tracker = new Utils.ProgressTracker(_downloadReporter, 3);
+                var downloadTask = _manutencoes.ObterDadosAsync(tracker.NextSegment());
                 var instService = new InstalacaoService();
-                var instalacaoTask = instService.AtualizarArquivoAsync();
+                var instalacaoTask = instService.AtualizarArquivoAsync(tracker.NextSegment());
+                var uploadSeg = tracker.NextSegment();
                 await Task.WhenAll(downloadTask, instalacaoTask, backupTask);
+                uploadSeg.Report(100);
                 _manutencoes.ClearData();
 
                 if (backupTask.Status == TaskStatus.RanToCompletion)

--- a/Services/InstalacaoService.cs
+++ b/Services/InstalacaoService.cs
@@ -87,11 +87,13 @@ namespace OrganizadorArquivosWPF.Services
         /// Baixa o arquivo de instalação do SharePoint substituindo
         /// qualquer versão local existente.
         /// </summary>
-        public async Task AtualizarArquivoAsync()
+        public async Task AtualizarArquivoAsync(IProgress<int>? progress = null)
         {
             try
             {
+                progress?.Report(0);
                 await BaixarArquivoAsync();
+                progress?.Report(100);
             }
             catch (Exception ex)
             {

--- a/Services/TrayService.cs
+++ b/Services/TrayService.cs
@@ -83,9 +83,11 @@ namespace OrganizadorArquivosWPF.Services
                         {
                             try
                             {
-                                await _manutencoes.ObterDadosAsync(_progress);
+                                var tracker = new Utils.ProgressTracker(_progress, 2);
+                                await _manutencoes.ObterDadosAsync(tracker.NextSegment());
                                 _manutencoes.ClearData();
-                                await _instalacao.AtualizarArquivoAsync();
+                                await _instalacao.AtualizarArquivoAsync(tracker.NextSegment());
+                                _progress?.Report(100);
                             }
                             catch (Exception ex) { _log.Error($"Download manual: {ex.Message}"); }
                         }
@@ -109,13 +111,14 @@ namespace OrganizadorArquivosWPF.Services
 
         public async Task StartAsync(IProgress<int> progress)
         {
-
             _progress = progress;
+            var tracker = new Utils.ProgressTracker(progress, 2);
             try
             {
-                await _manutencoes.ObterDadosAsync(progress);
+                await _manutencoes.ObterDadosAsync(tracker.NextSegment());
                 _manutencoes.ClearData();
-                await _instalacao.AtualizarArquivoAsync();
+                await _instalacao.AtualizarArquivoAsync(tracker.NextSegment());
+                progress?.Report(100);
             }
             catch { }
             _manutencoes.StartAutoUpdate(_interval, progress);

--- a/Utils/ProgressUtils.cs
+++ b/Utils/ProgressUtils.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace OrganizadorArquivosWPF.Utils
+{
+    /// <summary>
+    /// Utility classes to compose progress of multiple sequential tasks.
+    /// </summary>
+    public class ProgressTracker
+    {
+        private readonly IProgress<int> _outer;
+        private readonly int _totalSegments;
+        private int _current;
+
+        public ProgressTracker(IProgress<int> outer, int totalSegments)
+        {
+            _outer = outer;
+            _totalSegments = Math.Max(1, totalSegments);
+            _current = 0;
+        }
+
+        /// <summary>
+        /// Gets a progress instance that maps its 0-100 range to the next segment
+        /// of the outer progress.
+        /// </summary>
+        public IProgress<int> NextSegment()
+        {
+            int index = _current++;
+            int start = index * 100 / _totalSegments;
+            int end = (index + 1) * 100 / _totalSegments;
+            return new Progress<int>(v =>
+            {
+                v = Math.Clamp(v, 0, 100);
+                int scaled = start + (v * (end - start) / 100);
+                _outer.Report(scaled);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ProgressTracker` helper for aggregated progress
- report progress when updating installation file
- aggregate progress across maintenance and installation downloads
- include employee file in splash progress and manual sync progress

## Testing
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fee45b5c8333bd21e73d07d5077a