### PR TITLE
Ensure app closes after launching updater

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -77,6 +77,9 @@ namespace OrganizadorArquivosWPF
             {
                 RunUpdaterExe();
                 Shutdown();
+                // Garante que o processo finalize para evitar erros na
+                // substituição dos arquivos durante a atualização
+                Environment.Exit(0);
                 return;
             }
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -484,6 +484,11 @@ namespace OrganizadorArquivosWPF
             });
 
             await Task.Delay(500);
+
+            // Permite o fechamento da janela e encerra o aplicativo
+            AllowClose = true;
+            Application.Current?.Shutdown();
+            Environment.Exit(0);
         }
 
         private void BtnSelecionar_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- exit the application after opening the updater from the startup prompt
- close the main window and exit when updating from the UI

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e88f4d3ac83338aa59a92e4d82163