### PR TITLE
Fix tray reactivation login behavior

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -174,6 +174,18 @@ namespace OrganizadorArquivosWPF
                                 Utils.WindowHelper.SetForegroundWindow(handle);
                             }
                         }
+                        else
+                        {
+                            var login = new LoginWindow();
+                            bool? loginOk = login.ShowDialog();
+                            if (loginOk == true)
+                            {
+                                UsuarioRecord user = login.Usuario;
+                                var newMain = new MainWindow(user);
+                                Current.MainWindow = newMain;
+                                newMain.Show();
+                            }
+                        }
                     });
                 }
             });


### PR DESCRIPTION
## Summary
- ensure login window reopens when activating from tray or second instance

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc3868ebc83339f00a0654dab0b2c