### PR TITLE
Fix worker host setup

### DIFF
--- a/SyncWorker/Program.cs
+++ b/SyncWorker/Program.cs
@@ -1,17 +1,18 @@
-using Microsoft.Extensions.Hosting;
-using SyncWorker;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using SyncWorker;
 
-var builder = Host.CreateApplicationBuilder(args);
-builder.Services.AddHostedService<Worker>();
+IHost host = Host.CreateDefaultBuilder(args)
+    .UseWindowsService()
+    .ConfigureServices((context, services) =>
+    {
+        services.AddHostedService<Worker>();
+        services.Configure<HostOptions>(options =>
+        {
+            options.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore;
+        });
+    })
+    .Build();
 
-builder.Services.Configure<HostOptions>(o =>
-{
-    o.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore;
-});
-
-builder.UseWindowsService();
-
-var host = builder.Build();
 host.Run();


### PR DESCRIPTION
## Summary
- simplify SyncWorker setup using `Host.CreateDefaultBuilder`

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fcdb8034883339e19a36da575550e