### PR TITLE
Fix missing LoggerFactory reference

### DIFF
--- a/SyncWorker/SyncWorker.csproj
+++ b/SyncWorker/SyncWorker.csproj
@@ -11,5 +11,6 @@
   <ItemGroup>
     <ProjectReference Include="../OrganizadorArquivosWPF.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add explicit `Microsoft.Extensions.Logging` dependency to SyncWorker

## Testing
- `dotnet restore SyncWorker/SyncWorker.csproj`
- `dotnet build SyncWorker/SyncWorker.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd109a68c8333a01da9763e6b934a