### PR TITLE
Improve progress accuracy

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -43,7 +43,7 @@ namespace OrganizadorArquivosWPF
             splash.Show();
 
             _tray = new TrayService();
-            var progress = new Progress<int>(v => splash.SetProgress(v));
+            var progress = new Progress<double>(v => splash.SetProgress(v));
             var tracker = new Utils.ProgressTracker(progress, 2);
 
             // Executa downloads em paralelo e limita o tempo de espera

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -302,6 +302,8 @@
                             </Grid.ColumnDefinitions>
                             <ProgressBar x:Name="Progress" Grid.Column="0" Height="18"
                                          IsIndeterminate="false" Visibility="Collapsed" Value="0"/>
+                            <TextBlock x:Name="ProgressPercentText" Grid.Column="1" Margin="8,0,0,0"
+                                       VerticalAlignment="Center" Visibility="Collapsed"/>
                         </Grid>
                     </Grid>
                 </Border>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -30,19 +30,23 @@ namespace OrganizadorArquivosWPF
         private const string PastaDefaultNome = "SALVAR AQUI";
 
         #region Progresso UI
-        private sealed class BarProgress : IProgress<int>
+        private sealed class BarProgress : IProgress<double>
         {
             private readonly MainWindow _wnd;
             public BarProgress(MainWindow wnd) => _wnd = wnd;
-            public void Report(int value)
-                => _wnd.Dispatcher.Invoke(() => _wnd.Progress.Value = value);
+            public void Report(double value)
+                => _wnd.Dispatcher.Invoke(() =>
+                {
+                    _wnd.Progress.Value = value;
+                    _wnd.ProgressPercentText.Text = $"{value:0.#}%";
+                });
         }
 
-        private sealed class DownloadProgress : IProgress<int>
+        private sealed class DownloadProgress : IProgress<double>
         {
             private readonly MainWindow _wnd;
             public DownloadProgress(MainWindow wnd) => _wnd = wnd;
-            public void Report(int value)
+            public void Report(double value)
             {
                 _wnd.Dispatcher.Invoke(() =>
                 {
@@ -66,7 +70,7 @@ namespace OrganizadorArquivosWPF
                             _wnd.DownloadBar.Visibility = Visibility.Visible;
                         _wnd.DownloadBar.IsIndeterminate = false;
                         _wnd.DownloadBar.Value = value;
-                        _wnd.TxtSyncStatus.Text = $"Baixando dados ({value}%)";
+                        _wnd.TxtSyncStatus.Text = $"Baixando dados ({value:0.#}%)";
                     }
                 });
             }
@@ -236,7 +240,7 @@ namespace OrganizadorArquivosWPF
                         int total = _cachedRecords.Count;
                         for (int i = 0; i < total; i++)
                         {
-                            reporter.Report((int)((i + 1) * 100.0 / total));
+                            reporter.Report((i + 1) * 100.0 / total);
                             var r = _cachedRecords[i];
                             if (r.NumOS.Equals(fullOS, StringComparison.OrdinalIgnoreCase))
                                 return r;
@@ -363,7 +367,12 @@ namespace OrganizadorArquivosWPF
         {
             BtnProcessar.IsEnabled = !ativo;
             Progress.Visibility = ativo ? Visibility.Visible : Visibility.Collapsed;
-            if (!ativo) Progress.Value = 0;
+            ProgressPercentText.Visibility = ativo ? Visibility.Visible : Visibility.Collapsed;
+            if (!ativo)
+            {
+                Progress.Value = 0;
+                ProgressPercentText.Text = "0%";
+            }
         }
 
         private void DefinirPastaPadrao()
@@ -387,6 +396,9 @@ namespace OrganizadorArquivosWPF
             Progress.Maximum = 100;
             Progress.IsIndeterminate = false;
             Progress.Visibility = Visibility.Collapsed;
+            ProgressPercentText.Visibility = Visibility.Collapsed;
+            Progress.Value = 0;
+            ProgressPercentText.Text = "0%";
         }
 
         private void ConfigurarDownloadBar()

--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -345,7 +345,7 @@ public class BackupService
         bool enviarParaNuvem,
         string nomeFuncionario,
         string matriculaFuncionario,
-        IProgress<int>? progress = null)
+        IProgress<double>? progress = null)
     {
         if (string.IsNullOrWhiteSpace(pastaOrigem) || !Directory.Exists(pastaOrigem))
             throw new DirectoryNotFoundException("Pasta de origem inválida para backup.");

--- a/Services/InstalacaoService.cs
+++ b/Services/InstalacaoService.cs
@@ -87,7 +87,7 @@ namespace OrganizadorArquivosWPF.Services
         /// Baixa o arquivo de instalação do SharePoint substituindo
         /// qualquer versão local existente.
         /// </summary>
-        public async Task AtualizarArquivoAsync(IProgress<int>? progress = null)
+        public async Task AtualizarArquivoAsync(IProgress<double>? progress = null)
         {
             try
             {

--- a/Services/ManutencoesService.cs
+++ b/Services/ManutencoesService.cs
@@ -35,7 +35,7 @@ namespace OrganizadorArquivosWPF.Services
         private JArray _dados = new JArray();
         private List<ClientRecord> _records = new List<ClientRecord>();
         private Timer _timer;
-        private IProgress<int> _timerProgress;
+        private IProgress<double> _timerProgress;
         private bool _executandoAtualizacao;
         private static LoggerService _log => LoggerService.Instance;
 
@@ -65,7 +65,7 @@ namespace OrganizadorArquivosWPF.Services
             }
         }
 
-        public async Task<JArray> ObterDadosAsync(IProgress<int> progress = null)
+        public async Task<JArray> ObterDadosAsync(IProgress<double> progress = null)
         {
             progress?.Report(0);
             bool fromInternet = false;
@@ -124,7 +124,7 @@ namespace OrganizadorArquivosWPF.Services
         }
 
         private async Task<Dictionary<string, string>> BaixarUltimosArquivosManutencaoAsync(
-            IProgress<int> progress, int maxTentativas = 3)
+            IProgress<double> progress, int maxTentativas = 3)
         {
             for (int tentativa = 1; tentativa <= maxTentativas; tentativa++)
             {
@@ -169,7 +169,7 @@ namespace OrganizadorArquivosWPF.Services
             }
         }
 
-        private async Task<Dictionary<string, string>> BaixarArquivosSharePointInternoAsync(IProgress<int> progress)
+        private async Task<Dictionary<string, string>> BaixarArquivosSharePointInternoAsync(IProgress<double> progress)
         {
             string driveId = await ObterDriveIdAsync();
 
@@ -202,7 +202,7 @@ namespace OrganizadorArquivosWPF.Services
                 {
                     _log.Warning($"Não encontrou arquivo para '{padrao}'.");
                     concluidos++;
-                    progress?.Report(concluidos * 100 / totalEtapas);
+                    progress?.Report(concluidos * 100.0 / totalEtapas);
                     continue;
                 }
 
@@ -226,7 +226,7 @@ namespace OrganizadorArquivosWPF.Services
                 finally
                 {
                     concluidos++;
-                    progress?.Report(concluidos * 100 / totalEtapas);
+                    progress?.Report(concluidos * 100.0 / totalEtapas);
                 }
             }
 
@@ -334,7 +334,7 @@ namespace OrganizadorArquivosWPF.Services
             }
         }
 
-        public async Task<List<ClientRecord>> ObterClientRecordsAsync(IProgress<int> p = null)
+        public async Task<List<ClientRecord>> ObterClientRecordsAsync(IProgress<double> p = null)
         {
             await ObterDadosAsync(p);
             return new List<ClientRecord>(_records);
@@ -364,7 +364,7 @@ namespace OrganizadorArquivosWPF.Services
             }
         }
 
-        public void StartAutoUpdate(TimeSpan interval, IProgress<int> p = null)
+        public void StartAutoUpdate(TimeSpan interval, IProgress<double> p = null)
         {
             if (_timer != null) return;
 

--- a/Services/RenamerService.cs
+++ b/Services/RenamerService.cs
@@ -182,14 +182,14 @@ namespace OrganizadorArquivosWPF.Services
             string devDestino,
             string nomeFuncionario,
             string matriculaFuncionario,
-            IProgress<int> progress = null)
+            IProgress<double> progress = null)
         {
             // Task.Run mantém compatibilidade com .NET 4.x (não há async streams etc.)
             return Task.Run(() =>
             {
                 bool isSistema160 = string.Equals(tipoSistema, "SIGFI160", StringComparison.OrdinalIgnoreCase);
-                int pct = 0;
-                void Report(int v) { pct = v; progress?.Report(v); }
+                double pct = 0;
+                void Report(double v) { pct = v; progress?.Report(v); }
 
                 _lastMapping.Clear();
                 Report(0);
@@ -288,7 +288,7 @@ namespace OrganizadorArquivosWPF.Services
                 // Cálculo de progresso (80 % do total, 10 % já foi)
                 int totalSteps = controllers.Count + (inv != null ? 1 : 0) + (bat != null ? 1 : 0) + images.Count + 2;
                 int done = 0;
-                void Step() => Report(10 + (++done * 80 / totalSteps));
+                void Step() => Report(10 + (++done * 80.0 / totalSteps));
 
                 // 8) Função local de mover/renomear
                 Action<string, string> MoveRen = (src, suf) =>

--- a/Services/TrayService.cs
+++ b/Services/TrayService.cs
@@ -20,7 +20,7 @@ namespace OrganizadorArquivosWPF.Services
         // A primeira sincronização já ocorre na tela splash. Por isso, a
         // próxima tentativa de download só deve acontecer após 10 minutos.
         private readonly TimeSpan _interval = TimeSpan.FromMinutes(10);
-        private IProgress<int> _progress;
+        private IProgress<double> _progress;
         private LoggerService _log => LoggerService.Instance;
 
         public TrayService()
@@ -109,7 +109,7 @@ namespace OrganizadorArquivosWPF.Services
             _icon.ContextMenuStrip = menu;
         }
 
-        public async Task StartAsync(IProgress<int> progress)
+        public async Task StartAsync(IProgress<double> progress)
         {
             _progress = progress;
             var tracker = new Utils.ProgressTracker(progress, 2);

--- a/Utils/ProgressUtils.cs
+++ b/Utils/ProgressUtils.cs
@@ -7,11 +7,11 @@ namespace OrganizadorArquivosWPF.Utils
     /// </summary>
     public class ProgressTracker
     {
-        private readonly IProgress<int> _outer;
+        private readonly IProgress<double> _outer;
         private readonly int _totalSegments;
         private int _current;
 
-        public ProgressTracker(IProgress<int> outer, int totalSegments)
+        public ProgressTracker(IProgress<double> outer, int totalSegments)
         {
             _outer = outer;
             _totalSegments = Math.Max(1, totalSegments);
@@ -22,15 +22,15 @@ namespace OrganizadorArquivosWPF.Utils
         /// Gets a progress instance that maps its 0-100 range to the next segment
         /// of the outer progress.
         /// </summary>
-        public IProgress<int> NextSegment()
+        public IProgress<double> NextSegment()
         {
             int index = _current++;
-            int start = index * 100 / _totalSegments;
-            int end = (index + 1) * 100 / _totalSegments;
-            return new Progress<int>(v =>
+            double start = index * 100.0 / _totalSegments;
+            double end = (index + 1) * 100.0 / _totalSegments;
+            return new Progress<double>(v =>
             {
-                v = Math.Clamp(v, 0, 100);
-                int scaled = start + (v * (end - start) / 100);
+                v = Math.Clamp(v, 0.0, 100.0);
+                double scaled = start + (v * (end - start) / 100.0);
                 _outer.Report(scaled);
             });
         }

--- a/Views/SplashWindow.xaml.cs
+++ b/Views/SplashWindow.xaml.cs
@@ -17,7 +17,7 @@ namespace OrganizadorArquivosWPF.Views
             TxtStatus.Text = text;
         }
 
-        public void SetProgress(int value)
+        public void SetProgress(double value)
         {
             if (value < 0)
             {
@@ -30,7 +30,7 @@ namespace OrganizadorArquivosWPF.Views
             Progress.IsIndeterminate = false;
             if (value > 100) value = 100;
             Progress.Value = value;
-            PercentText.Text = $"{value}%";
+            PercentText.Text = $"{value:0.#}%";
 
             if (value >= 100)
                 TxtStatus.Text = "Download concluído";


### PR DESCRIPTION
## Summary
- show numeric progress in main window
- support `double` progress reporting
- enhance splash screen progress accuracy

## Testing
- `dotnet build` *(fails: `dotnet` not found)*
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687004d57af48333ac40cf64871646e9