### PR TITLE
Add automatic datalog sync

### DIFF
--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -336,6 +336,49 @@ public class BackupService
         return resultados;
     }
 
+    /// <summary>
+    /// Sincroniza todas as pastas de datalog presentes no diretório raiz
+    /// enviando-as para o SharePoint caso ainda não existam lá.
+    /// </summary>
+    public async Task SincronizarPastasAsync(string diretorioRaiz)
+    {
+        if (string.IsNullOrWhiteSpace(diretorioRaiz) || !Directory.Exists(diretorioRaiz))
+            return;
+
+        string driveId = await ObterDriveIdAsync();
+
+        foreach (var dir in Directory.GetDirectories(diretorioRaiz))
+        {
+            string nome = ExtrairOs(dir) ?? Path.GetFileName(dir);
+            bool exists = true;
+            try
+            {
+                await _graph.Drives[driveId].Root.ItemWithPath(nome).GetAsync();
+            }
+            catch (ApiException ex) when (ex.ResponseStatusCode == (int)HttpStatusCode.NotFound)
+            {
+                exists = false;
+            }
+            catch (Exception ex)
+            {
+                _log.Error($"Erro ao verificar pasta '{nome}': {ex.Message}");
+                continue;
+            }
+
+            if (!exists)
+            {
+                try
+                {
+                    await EnviarBackupAsync(dir, nome);
+                }
+                catch (Exception ex)
+                {
+                    _log.Error($"Falha ao sincronizar '{dir}': {ex.Message}");
+                }
+            }
+        }
+    }
+
     public async Task ProcessarBackupAsync(
         string pastaOrigem,
         ClientRecord registro,

--- a/Services/TrayService.cs
+++ b/Services/TrayService.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Windows;
 using System.Windows.Forms;
 using System.Threading.Tasks;
+using System.IO;
 using OrganizadorArquivosWPF;
 
 namespace OrganizadorArquivosWPF.Services
@@ -16,6 +17,7 @@ namespace OrganizadorArquivosWPF.Services
         private readonly NotifyIcon _icon;
         private readonly ManutencoesService _manutencoes;
         private readonly InstalacaoService _instalacao;
+        private readonly BackupService _backup;
         // Intervalo padrão para atualizações automáticas
         // A primeira sincronização já ocorre na tela splash. Por isso, a
         // próxima tentativa de download só deve acontecer após 10 minutos.
@@ -27,6 +29,7 @@ namespace OrganizadorArquivosWPF.Services
         {
             _manutencoes = new ManutencoesService();
             _instalacao = new InstalacaoService();
+            _backup = new BackupService();
 
             var icoPath = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ico-app.ico");
             _icon = new NotifyIcon
@@ -123,6 +126,19 @@ namespace OrganizadorArquivosWPF.Services
 
                 var instProg = new Progress<double>(v => progress?.Report(50 + v * 0.5));
                 await _instalacao.AtualizarArquivoAsync(instProg);
+
+                if (!string.IsNullOrWhiteSpace(Config.BackupFolder) &&
+                    Directory.Exists(Config.BackupFolder))
+                {
+                    try
+                    {
+                        await _backup.SincronizarPastasAsync(Config.BackupFolder);
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Error($"Backup inicial: {ex.Message}");
+                    }
+                }
 
                 progress?.Report(100);
             }


### PR DESCRIPTION
## Summary
- sync local datalog folders at startup using `BackupService`
- trigger this sync from `TrayService`

## Testing
- `dotnet --info`
- `dotnet build --nologo OrganizadorArquivosWPF.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687128e40bb4833384dd1599a6485e40