### PR TITLE
Add recursive sync for renamed folders

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -667,6 +667,12 @@ namespace OrganizadorArquivosWPF
                 uploadSeg.Report(100);
                 _manutencoes.ClearData();
 
+                if (_backup != null)
+                {
+                    try { await _backup.SincronizarPastasRenomeacaoAsync(); }
+                    catch (Exception ex) { _log.Error($"Sincronizacao: {ex.Message}"); }
+                }
+
                 if (backupTask.Status == TaskStatus.RanToCompletion)
                 {
                     var enviados = backupTask.Result.Count(r => r.Verificado);

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ dotnet run
 
 Alternatively open the `OrganizadorArquivosWPF.csproj` file in Visual Studio and run the project.
 
+When pressing **Sincronizar Tudo** in the application, all local folders created by the renamer (AC/MT or in *Documentos*) that contain a service order number are scanned and automatically uploaded to the **DatalogGERAL** library on SharePoint if they are not already present.
+
 ### Background Sync Service
 
 The `SyncWorker` project builds a Windows service that synchronizes data every 10 minutes.

--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -379,6 +379,55 @@ public class BackupService
         }
     }
 
+    /// <summary>
+    /// Procura recursivamente por pastas de OS dentro das pastas de renomeação
+    /// (AC, MT ou Documentos) e envia para o SharePoint caso ainda não existam.
+    /// </summary>
+    public async Task SincronizarPastasRenomeacaoAsync()
+    {
+        string driveId = await ObterDriveIdAsync();
+
+        foreach (var baseDir in RenamerService.EnumerarPastasBase())
+        {
+            if (!Directory.Exists(baseDir))
+                continue;
+
+            foreach (var dir in Directory.GetDirectories(baseDir, "*", SearchOption.AllDirectories))
+            {
+                var nome = ExtrairOs(dir);
+                if (string.IsNullOrWhiteSpace(nome))
+                    continue;
+
+                bool exists = true;
+                try
+                {
+                    await _graph.Drives[driveId].Root.ItemWithPath(nome).GetAsync();
+                }
+                catch (ApiException ex) when (ex.ResponseStatusCode == (int)HttpStatusCode.NotFound)
+                {
+                    exists = false;
+                }
+                catch (Exception ex)
+                {
+                    _log.Error($"Erro ao verificar pasta '{nome}': {ex.Message}");
+                    continue;
+                }
+
+                if (!exists)
+                {
+                    try
+                    {
+                        await EnviarBackupAsync(dir, nome);
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Error($"Falha ao sincronizar '{dir}': {ex.Message}");
+                    }
+                }
+            }
+        }
+    }
+
     public async Task ProcessarBackupAsync(
         string pastaOrigem,
         ClientRecord registro,

--- a/Services/RenamerService.cs
+++ b/Services/RenamerService.cs
@@ -125,6 +125,34 @@ namespace OrganizadorArquivosWPF.Services
             Directory.CreateDirectory(destino);
             return destino;
         }
+
+        /// <summary>
+        /// Obtém todas as pastas base existentes utilizadas pelo renomeador
+        /// tanto para AC quanto para MT, além da pasta "OrganizadorArquivos"
+        /// em Documentos, se houver.
+        /// </summary>
+        public static IEnumerable<string> EnumerarPastasBase()
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var raiz = Path.Combine(home, RaizOneEng);
+
+            IEnumerable<string> Enumerar(string mask) =>
+                Enumerable.Range(1, 100)
+                          .Select(n => Path.Combine(raiz, string.Format(mask, n)))
+                          .Where(Directory.Exists);
+
+            foreach (var dir in Enumerar("ONE Engenharia - Clientes PC ONE {0:D3}"))
+                yield return dir;
+
+            foreach (var dir in Enumerar("ONE Engenharia - LOGIN_W_{0:D3}_R_MT"))
+                yield return dir;
+
+            var docs = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                "OrganizadorArquivos");
+            if (Directory.Exists(docs))
+                yield return docs;
+        }
         #endregion
 
         #region Classificação de Arquivos


### PR DESCRIPTION
## Summary
- enumerate all renaming base folders (AC/MT/Documents)
- add recursive synchronization of OS folders to BackupService
- trigger new sync when user presses **Sincronizar Tudo**
- document new behaviour in README

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687156072f6483339c31c78854e8fd2d