### PR TITLE
Fix BackupCache concurrency issues

### DIFF
--- a/Services/BackupCache.cs
+++ b/Services/BackupCache.cs
@@ -5,11 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Threading;
 
 namespace OrganizadorArquivosWPF.Services;
 
 public sealed class BackupCache
 {
+    private static readonly Mutex _fileMutex = new(false, "Global\\OneEngRenamer_BackupCache");
+    private readonly object _lock = new();
     private readonly string _path;
     private readonly Dictionary<string, HashSet<string>> _map;
 
@@ -19,32 +22,67 @@ public sealed class BackupCache
         _map = Carregar(path);
     }
 
-    public bool Contains(string pasta, string nomeArquivo) =>
-        _map.TryGetValue(pasta, out var set) && set.Contains(nomeArquivo);
+    public bool Contains(string pasta, string nomeArquivo)
+    {
+        lock (_lock)
+            return _map.TryGetValue(pasta, out var set) && set.Contains(nomeArquivo);
+    }
 
     public void Add(string pasta, string nomeArquivo)
     {
-        if (!_map.TryGetValue(pasta, out var set))
+        lock (_lock)
         {
-            set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            _map[pasta] = set;
+            if (!_map.TryGetValue(pasta, out var set))
+            {
+                set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                _map[pasta] = set;
+            }
+            set.Add(nomeArquivo);
         }
-        set.Add(nomeArquivo);
     }
 
     public void Save()
     {
-        Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
-        File.WriteAllText(
-            _path,
-            JsonSerializer.Serialize(_map,
-                new JsonSerializerOptions { WriteIndented = true }));
+        lock (_lock)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+            bool acquired = false;
+            try
+            {
+                try { _fileMutex.WaitOne(); acquired = true; }
+                catch (AbandonedMutexException) { acquired = true; }
+
+                for (int i = 0; ; i++)
+                {
+                    try
+                    {
+                        File.WriteAllText(
+                            _path,
+                            JsonSerializer.Serialize(_map,
+                                new JsonSerializerOptions { WriteIndented = true }));
+                        break;
+                    }
+                    catch (IOException) when (i < 4)
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
+            }
+            finally
+            {
+                if (acquired) _fileMutex.ReleaseMutex();
+            }
+        }
     }
 
     private static Dictionary<string, HashSet<string>> Carregar(string path)
     {
+        bool acquired = false;
         try
         {
+            try { _fileMutex.WaitOne(); acquired = true; }
+            catch (AbandonedMutexException) { acquired = true; }
+
             if (File.Exists(path))
             {
                 var json = File.ReadAllText(path);
@@ -54,6 +92,10 @@ public sealed class BackupCache
             }
         }
         catch { /* Se der ruim, começa do zero */ }
+        finally
+        {
+            if (acquired) _fileMutex.ReleaseMutex();
+        }
         return new(StringComparer.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Summary
- prevent `BackupCache.json` write conflicts using a mutex and locks

## Testing
- `dotnet build OrganizadorArquivosWPF.csproj --no-restore` *(fails: SDK `Microsoft.NET.Sdk.WindowsDesktop` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68756f61b08c83339e82a71f3244cf10