### PR TITLE
Add global exception handlers

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interop;
+using System.Windows.Threading;
 
 namespace OrganizadorArquivosWPF
 {
@@ -43,6 +44,9 @@ namespace OrganizadorArquivosWPF
             }
 
             StartShowEventListener();
+            DispatcherUnhandledException += OnDispatcherUnhandledException;
+            AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+            TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
             base.OnStartup(e);
             EnsureRunAtStartup();
 
@@ -216,6 +220,26 @@ namespace OrganizadorArquivosWPF
                 break;
             }
         }
+
+        #region Global exception handlers
+        private void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+        {
+            LoggerService.Instance?.Critical("UI exception: " + e.Exception.Message);
+            e.Handled = true;
+        }
+
+        private void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            if (e.ExceptionObject is Exception ex)
+                LoggerService.Instance?.Critical("Unhandled exception: " + ex.Message);
+        }
+
+        private void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            LoggerService.Instance?.Critical("Task exception: " + e.Exception.Message);
+            e.SetObserved();
+        }
+        #endregion
         #endregion
     }
 }


### PR DESCRIPTION
## Summary
- add `System.Windows.Threading` import
- hook global exception events in `App` startup
- log and handle dispatcher, domain, and task exceptions

## Testing
- `dotnet build OrganizadorArquivosWPF.csproj` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876ad7002908333ae6a7423b52fd2b8