### PR TITLE
Fix upload progress bar visibility

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -89,12 +89,14 @@ namespace OrganizadorArquivosWPF
                         _wnd.UploadBar.Value = 100;
                         _wnd.UploadBar.Visibility = Visibility.Collapsed;
                         _wnd.UploadBar.IsIndeterminate = false;
+                        _wnd.TxtSyncStatus.Text = "Backup concluído";
                     }
                     else if (value < 0)
                     {
                         if (_wnd.UploadBar.Visibility != Visibility.Visible)
                             _wnd.UploadBar.Visibility = Visibility.Visible;
                         _wnd.UploadBar.IsIndeterminate = true;
+                        _wnd.TxtSyncStatus.Text = "Preparando upload...";
                     }
                     else
                     {
@@ -102,6 +104,7 @@ namespace OrganizadorArquivosWPF
                             _wnd.UploadBar.Visibility = Visibility.Visible;
                         _wnd.UploadBar.IsIndeterminate = false;
                         _wnd.UploadBar.Value = value;
+                        _wnd.TxtSyncStatus.Text = $"Enviando backup ({value:0.#}%)";
                     }
                 });
             }

--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -107,6 +107,8 @@ public sealed class BackupService
         var res = new List<FileUploadResult>();
         if (!Directory.Exists(pasta)) return res;
 
+        progress?.Report(-1); // inicia barra indeterminada
+
         numOs ??= ExtrairOs(pasta);
         if (string.IsNullOrWhiteSpace(numOs)) return res;
 


### PR DESCRIPTION
## Summary
- improve UploadBar progress feedback with status text
- show indeterminate state when backup starts

## Testing
- `dotnet test --no-build` *(fails: project uses WindowsDesktop SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6876b4bcec14833398586e76c0327fa5