### PR TITLE
Fix backup and sync exception handling

### DIFF
--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -153,7 +153,18 @@ public sealed class BackupService
         await Task.WhenAll(tasks).ConfigureAwait(false);
 
         // ZIP
-        string zip = CriarZipTemporario(pasta, out string zipName);
+        string zip;
+        string zipName;
+        try
+        {
+            zip = CriarZipTemporario(pasta, out zipName);
+        }
+        catch (Exception ex)
+        {
+            _log.Error($"Falha ao criar ZIP '{pasta}': {ex.Message}");
+            progress?.Report(100);
+            return res;
+        }
         if (!_cache.Contains(numOs, zipName))
         {
             try
@@ -178,10 +189,47 @@ public sealed class BackupService
     #endregion
 
     #region Listagem & helpers
-    private static IEnumerable<string> EnumerarPastasParaBackup() =>
-        RenamerService.EnumerarPastasBase()
-            .SelectMany(d => Directory.EnumerateDirectories(d, "*", SearchOption.AllDirectories))
-            .Where(d => Directory.EnumerateFiles(d).Any());
+    private static IEnumerable<string> EnumerarPastasParaBackup()
+    {
+        foreach (var baseDir in RenamerService.EnumerarPastasBase())
+        {
+            foreach (var dir in SafeEnumerateDirectories(baseDir))
+            {
+                if (HasFiles(dir))
+                    yield return dir;
+            }
+        }
+    }
+
+    private static IEnumerable<string> SafeEnumerateDirectories(string root)
+    {
+        var stack = new Stack<string>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            yield return current;
+            try
+            {
+                foreach (var sub in Directory.GetDirectories(current))
+                    stack.Push(sub);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                LoggerService.Instance.Warning($"Falha ao enumerar '{current}': {ex.Message}");
+            }
+        }
+    }
+
+    private static bool HasFiles(string dir)
+    {
+        try { return Directory.EnumerateFiles(dir).Any(); }
+        catch (Exception ex)
+        {
+            LoggerService.Instance.Warning($"Falha ao ler '{dir}': {ex.Message}");
+            return false;
+        }
+    }
 
     private async Task<HashSet<string>> ArquivosRemotosAsync(
         string driveId, string folderId, CancellationToken ct)

--- a/Services/FileSyncService.cs
+++ b/Services/FileSyncService.cs
@@ -25,42 +25,56 @@ public sealed class FileSyncService : IAsyncDisposable
 
         // 1) Cria watchers para cada base
         _watchers = RenamerService.EnumerarPastasBase()
-                                  .Select(CreateWatcher)
-                                  .ToArray();
+                                  .Select(TryCreateWatcher)
+                                  .Where(w => w != null)
+                                  .ToArray()!;
 
         // 2) Worker que processa a fila até o Cancel
         _worker = Task.Run(ProcessQueueAsync);
     }
 
     // --- Começa a vigiar uma raiz recursivamente
-    private FileSystemWatcher CreateWatcher(string path)
+    private FileSystemWatcher? TryCreateWatcher(string path)
     {
-        var fsw = new FileSystemWatcher(path)
+        try
         {
-            IncludeSubdirectories = true,
-            NotifyFilter = NotifyFilters.FileName
-                           | NotifyFilters.DirectoryName
-                           | NotifyFilters.LastWrite
-        };
+            var fsw = new FileSystemWatcher(path)
+            {
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.FileName
+                               | NotifyFilters.DirectoryName
+                               | NotifyFilters.LastWrite
+            };
 
-        fsw.Created += OnChanged;
-        fsw.Changed += OnChanged;
-        fsw.Renamed += OnRenamed;
-        fsw.EnableRaisingEvents = true;
-        return fsw;
+            fsw.Created += OnChanged;
+            fsw.Changed += OnChanged;
+            fsw.Renamed += OnRenamed;
+            fsw.EnableRaisingEvents = true;
+            return fsw;
+        }
+        catch (Exception ex)
+        {
+            LoggerService.Instance.Warning($"Watcher falhou em '{path}': {ex.Message}");
+            return null;
+        }
     }
 
     private void OnChanged(object sender, FileSystemEventArgs e)
     {
-        // Considera apenas arquivos concretos
         if (File.Exists(e.FullPath))
-            _queue.Add(e.FullPath);
+        {
+            try { _queue.Add(e.FullPath); }
+            catch (InvalidOperationException) { }
+        }
     }
 
     private void OnRenamed(object sender, RenamedEventArgs e)
     {
         if (File.Exists(e.FullPath))
-            _queue.Add(e.FullPath);
+        {
+            try { _queue.Add(e.FullPath); }
+            catch (InvalidOperationException) { }
+        }
     }
 
     // --- Loop infinito que agrupa por pasta e chama BackupService
@@ -74,6 +88,7 @@ public sealed class FileSyncService : IAsyncDisposable
             string file;
             try { file = _queue.Take(_cts.Token); }
             catch (OperationCanceledException) { break; }
+            catch (InvalidOperationException) { break; }
 
             var pasta = Directory.GetParent(file)?.FullName;
             if (pasta == null) continue;


### PR DESCRIPTION
## Summary
- catch errors while creating backup zip
- safely enumerate backup folders without crashing on access errors
- guard FileSyncService queue operations from disposal exceptions
- ignore watcher creation failures and handle queue completion

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build OrganizadorArquivosWPF.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877b66cc878833392936444230b7beb