### PR TITLE
Fix upload progress and summary

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -76,7 +76,7 @@ namespace OrganizadorArquivosWPF
             _backup = new BackupService();
             try
             {
-                await _backup.SincronizarTudoAsync(cts.Token)
+                await _backup.SincronizarTudoAsync(null, cts.Token)
                              .ContinueWith(_ => track.NextSegment().Report(100));
             }
             catch { /* ignorar timeout */ }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -663,11 +663,15 @@ namespace OrganizadorArquivosWPF
                         }
 
                         var enviados = t.Result.Count(r => r.Verificado);
+                        var falhas = t.Result.Where(r => !r.Verificado)
+                                             .Select(r => r.Nome)
+                                             .ToList();
+                        var fail = falhas.Count;
                         Dispatcher.Invoke(() =>
                         {
                             if (_lastBackupEntry != null)
                                 _logs.Remove(_lastBackupEntry);
-                            _log.Info($"Backup concluído ({enviados} arquivos) às {DateTime.Now:HH:mm:ss}");
+                            _log.Info($"Backup concluído: OK={enviados} | Falhas={fail}{(fail > 0 ? $" ({string.Join(", ", falhas)})" : string.Empty)} às {DateTime.Now:HH:mm:ss}");
                             _lastBackupEntry = _logs.LastOrDefault();
                         });
                     });
@@ -724,18 +728,22 @@ namespace OrganizadorArquivosWPF
 
                 if (_backup != null)
                 {
-                    try { await _backup.SincronizarPastasRenomeacaoAsync(); }
+                    try { await _backup.SincronizarPastasRenomeacaoAsync(_uploadReporter); }
                     catch (Exception ex) { _log.Error($"Sincronizacao: {ex.Message}"); }
                 }
 
                 if (backupTask.Status == TaskStatus.RanToCompletion)
                 {
                     var enviados = backupTask.Result.Count(r => r.Verificado);
+                    var falhas = backupTask.Result.Where(r => !r.Verificado)
+                                                .Select(r => r.Nome)
+                                                .ToList();
+                    var fail = falhas.Count;
                     Dispatcher.Invoke(() =>
                     {
                         if (_lastBackupEntry != null)
                             _logs.Remove(_lastBackupEntry);
-                        _log.Info($"Backup concluído ({enviados} arquivos) às {DateTime.Now:HH:mm:ss}");
+                        _log.Info($"Backup concluído: OK={enviados} | Falhas={fail}{(fail > 0 ? $" ({string.Join(", ", falhas)})" : string.Empty)} às {DateTime.Now:HH:mm:ss}");
                         _lastBackupEntry = _logs.LastOrDefault();
                     });
                 }

--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -53,8 +53,11 @@ public sealed class BackupService
     }
 
     #region Ponto de entrada público
-    public async Task SincronizarTudoAsync(CancellationToken ct = default)
+    public async Task<IReadOnlyList<FileUploadResult>> SincronizarTudoAsync(
+        IProgress<UploadProgressInfo>? progress = null,
+        CancellationToken ct = default)
     {
+        progress?.Report(new UploadProgressInfo(-1, 0, 0, null));
         _ = await ObterDriveIdAsync(ct).ConfigureAwait(false);
 
         var pendentes = CarregarPendentes();
@@ -86,14 +89,26 @@ public sealed class BackupService
         await Task.WhenAll(workers).ConfigureAwait(false);
 
         _cache.Save();
-        _log.Info($"Backup: OK={resultados.Count(r => r.Verificado)} | Falhas={resultados.Count(r => !r.Verificado)}");
+        int ok = resultados.Count(r => r.Verificado);
+        var falhas = resultados.Where(r => !r.Verificado)
+                               .Select(r => r.Nome)
+                               .ToList();
+        int fail = falhas.Count;
+        progress?.Report(new UploadProgressInfo(100, ok + fail, ok + fail, null));
+        _log.Info($"Backup: OK={ok} | Falhas={fail}{(fail > 0 ? $" ({string.Join(", ", falhas)})" : string.Empty)}");
+        return resultados.ToList();
     }
 
-    public Task SincronizarPastasRenomeacaoAsync() =>
-    SincronizarTudoAsync();
 
-    public Task SincronizarPastasAsync(string _ = null) =>
-        SincronizarTudoAsync();
+    public Task<IReadOnlyList<FileUploadResult>> SincronizarPastasRenomeacaoAsync(
+        IProgress<UploadProgressInfo>? progress = null,
+        CancellationToken ct = default) =>
+        SincronizarTudoAsync(progress, ct);
+
+    public Task<IReadOnlyList<FileUploadResult>> SincronizarPastasAsync(string _ = null,
+        IProgress<UploadProgressInfo>? progress = null,
+        CancellationToken ct = default) =>
+        SincronizarTudoAsync(progress, ct);
 
     #endregion
 
@@ -139,9 +154,8 @@ public sealed class BackupService
                 _cache.Add(numOs, Path.GetFileName(file));
                 res.Add(new(Path.GetFileName(file), true, CalcularSha1(file)));
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                _log.Error($"Upload '{file}': {ex.Message}");
                 res.Add(new(Path.GetFileName(file), false, string.Empty));
             }
             finally
@@ -177,9 +191,8 @@ public sealed class BackupService
                 _cache.Add(numOs, zipName);
                 res.Add(new(zipName, true, CalcularSha1(zip)));
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                _log.Error($"Upload zip '{zip}': {ex.Message}");
                 res.Add(new(zipName, false, string.Empty));
             }
             finally

--- a/Services/FileSyncService.cs
+++ b/Services/FileSyncService.cs
@@ -149,7 +149,7 @@ public sealed class FileSyncService : IAsyncDisposable
 
         _ = Task.Run(async () =>
         {
-            try { await _backup.SincronizarTudoAsync(_cts.Token); }
+            try { await _backup.SincronizarTudoAsync(null, _cts.Token); }
             catch (Exception ex) { _log.Warning($"Auto sync reconectou: {ex.Message}"); }
         });
     }

--- a/Services/TrayService.cs
+++ b/Services/TrayService.cs
@@ -170,7 +170,7 @@ public sealed class TrayService : IDisposable, IAsyncDisposable
             try
             {
                 await Task.Delay(_interval, token);
-                await _backup.SincronizarTudoAsync(token);
+                await _backup.SincronizarTudoAsync(null, token);
             }
             catch (OperationCanceledException) { }
             catch (Exception ex) { _log.Warning($"Backup loop: {ex.Message}"); }


### PR DESCRIPTION
## Summary
- handle whole-backup progress in `BackupService`
- accept progress reporter in backup entry points
- show final summary with failed files
- silence per-file upload error logs
- forward reporter when syncing past renamed folders

## Testing
- `dotnet build OrganizadorArquivosWPF.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a92a869e08333bf0b5f6a303d3099