### PR TITLE
Reduce upload error log noise

### DIFF
--- a/OrganizadorArquivosWPF.sln
+++ b/OrganizadorArquivosWPF.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.13.35825.156
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrganizadorArquivosWPF", "OrganizadorArquivosWPF\OrganizadorArquivosWPF.csproj", "{486E8737-93A9-40CE-8053-3B71AC68AE50}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrganizadorArquivosWPF", "OrganizadorArquivosWPF.csproj", "{486E8737-93A9-40CE-8053-3B71AC68AE50}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Services/BackupService.cs
+++ b/Services/BackupService.cs
@@ -78,9 +78,8 @@ public sealed class BackupService
                     foreach (var r in list) resultados.Add(r);
                     RemoverPendente(dir);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
-                    _log.Error($"Falha em '{dir}': {ex.Message}");
                     RegistrarPendente(dir);
                 }
             }
@@ -182,9 +181,8 @@ public sealed class BackupService
         {
             zip = CriarZipTemporario(pasta, out zipName);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            _log.Error($"Falha ao criar ZIP '{pasta}': {ex.Message}");
             progress?.Report(new UploadProgressInfo(100, total, total, null));
             return res;
         }
@@ -212,7 +210,7 @@ public sealed class BackupService
                                                      done, total, zipName));
             }
         }
-        try { File.Delete(zip); } catch (Exception ex) { _log.Warning($"Falha ao remover arquivo temporário '{zip}': {ex.Message}"); }
+        try { File.Delete(zip); } catch { }
 
         progress?.Report(new UploadProgressInfo(100, total, total, null));
 
@@ -278,9 +276,8 @@ public sealed class BackupService
                 if (it.File != null) set.Add(it.Name);
             return set;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            _log.Error($"Falha ao listar arquivos remotos: {ex.Message}");
             throw;
         }
     }
@@ -300,9 +297,8 @@ public sealed class BackupService
             _driveId = drive.Id;
             return _driveId;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            _log.Error($"Falha ao obter DriveId: {ex.Message}");
             throw;
         }
     }
@@ -332,9 +328,8 @@ public sealed class BackupService
                                    .PostAsync(item, cancellationToken: ct)
                                    .ConfigureAwait(false))!.Id;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            _log.Error($"Falha ao garantir pasta '{nome}': {ex.Message}");
             throw;
         }
     }

--- a/Services/ReliableSharePointService.cs
+++ b/Services/ReliableSharePointService.cs
@@ -132,7 +132,6 @@ public sealed class ReliableSharePointService
                    ex.ResponseStatusCode == (int)HttpStatusCode.ServiceUnavailable)
             {
                 int delay = _baseDelay * (int)Math.Pow(2, attempt - 1);
-                _log.Info($"Throttle {ex.ResponseStatusCode} '{remotePath}' (tentativa {attempt}/{_maxRetries}) – aguardando {delay} ms.");
                 await Task.Delay(delay, ct).ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -141,7 +140,6 @@ public sealed class ReliableSharePointService
                     throw;
 
                 int delay = _baseDelay * attempt;
-                _log.Warning($"Erro upload '{remotePath}' tent. {attempt}: {ex.Message}. Retry em {delay} ms.");
                 await Task.Delay(delay, ct).ConfigureAwait(false);
             }
         }
@@ -165,12 +163,12 @@ public sealed class ReliableSharePointService
             if (!string.IsNullOrEmpty(remoteHash) &&
                 !string.Equals(remoteHash, localHash, StringComparison.OrdinalIgnoreCase))
             {
-                _log.Warning($"Hash divergente em '{remotePath}' – poss. corrupção!");
+                // Hash mismatch indicates possible corruption, but skip noisy log
             }
         }
         catch (Exception ex)
         {
-            _log.Warning($"Falha ao verificar hash '{remotePath}': {ex.Message}");
+            // Ignore hash verification errors silently
         }
     }
 


### PR DESCRIPTION
## Summary
- silence retry messages during upload
- skip noisy hash warnings
- remove per-item failure logs
- update solution path

## Testing
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa33fa5388333a9742f54fffcba32