### PR TITLE
Fix log panel text selection

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -120,6 +120,7 @@
             <Setter Property="FontWeight"          Value="Normal"/>
             <Setter Property="TextWrapping"        Value="Wrap"/>
             <Setter Property="Foreground"          Value="#1a1a1a"/>
+            <Setter Property="IsTextSelectionEnabled" Value="True"/>
         </Style>
 
         <!-- Linhas coloridas do log (pinta o BACKGROUND) -->


### PR DESCRIPTION
## Summary
- enable text selection inside the log grid cells

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa6c86ee08333bc596fa1a0b02461