### PR TITLE
Ensure employees file downloads on splash

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -77,8 +77,8 @@ namespace OrganizadorArquivosWPF
             // 2) planilha funcionários
             splash.SetStatus("Baixando planilha de funcionários...");
             var funcSrv = new FuncionariosService();
-            await Task.Run(funcSrv.ListarTodos, cts.Token)
-                      .ContinueWith(_ => track.NextSegment().Report(100));
+            await funcSrv.AtualizarArquivoAsync(track.NextSegment())
+                     .WaitAsync(cts.Token);
 
             // 3) sincronização inicial
             splash.SetStatus("Sincronizando arquivos com SharePoint...");

--- a/Services/FuncionariosService.cs
+++ b/Services/FuncionariosService.cs
@@ -27,8 +27,8 @@ namespace OrganizadorArquivosWPF.Services
         private string _driveId;
 
         private readonly string _csvPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "OneEngRenamer","OrganizadorArquivosWPF","funcionarios.csv");
+            AppDomain.CurrentDomain.BaseDirectory,
+            "funcionarios.csv");
 
         public FuncionariosService()
         {
@@ -85,6 +85,25 @@ namespace OrganizadorArquivosWPF.Services
             Directory.CreateDirectory(Path.GetDirectoryName(_csvPath));
             using var fs = File.Create(_csvPath);
             await stream.CopyToAsync(fs);
+        }
+
+        /// <summary>
+        /// Baixa o arquivo de funcionários do SharePoint substituindo
+        /// qualquer versão local existente.
+        /// </summary>
+        public async Task AtualizarArquivoAsync(IProgress<double>? progress = null)
+        {
+            try
+            {
+                progress?.Report(0);
+                await BaixarCsvSharePointAsync();
+                progress?.Report(100);
+            }
+            catch
+            {
+                // Caller handles exceptions as needed
+                throw;
+            }
         }
 
         private void GarantirArquivoLocal()


### PR DESCRIPTION
## Summary
- store `funcionarios.csv` in the application folder
- add method `AtualizarArquivoAsync` to `FuncionariosService`
- download employee list during splash screen using new method

## Testing
- `dotnet restore` *(fails: project requires WindowsDesktop SDK)*
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e5e7eb81883338cbb4ef9bfe565eb